### PR TITLE
Use the tvg-id and tvg-name from https://github.com/iptv-org/epg

### DIFF
--- a/swisscom-full.m3u
+++ b/swisscom-full.m3u
@@ -48,9 +48,9 @@ rtp://239.186.70.33:10000
 rtp://239.186.64.42:10000
 #EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="102" channel-id="102",TFX CH HD (ex NT1 HD)
 rtp://239.186.70.34:10000
-#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="CSTAR F" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
 rtp://239.186.64.59:10000
-#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="CSTAR F" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
 rtp://239.186.68.215:10000
 #EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
 rtp://239.186.66.24:10000
@@ -70,13 +70,13 @@ rtp://239.186.68.33:10000
 rtp://233.21.50.59:1234
 #EXTINF:-1 tvg-id="OCSCity" tvg-name="OCS City FR" tvg-logo="http://static.epg.best/fr/OCSCity.fr.png" tvg-chno="2" channel-id="2",OCS City FR
 rtp://233.21.50.60:1234
-#EXTINF:-1 tvg-id="OcsChoc" tvg-name="Ocs Choc FR" tvg-logo="http://static.epg.best/mu/OcsChoc.mu.png" tvg-chno="3" channel-id="3",OCS Choc FR
+#EXTINF:-1 tvg-id="OcsChoc" tvg-name="OCS Choc" tvg-logo="http://static.epg.best/mu/OcsChoc.mu.png" tvg-chno="3" channel-id="3",OCS Choc FR
 rtp://233.21.50.61:1234
-#EXTINF:-1 tvg-id="OcsGeants" tvg-name="Ocs Geants FR" tvg-logo="http://static.epg.best/mu/OcsGeants.mu.png" tvg-chno="4" channel-id="4",OCS Geants FR
+#EXTINF:-1 tvg-id="OcsGeants" tvg-name="OCS Géants" tvg-logo="http://static.epg.best/mu/OcsGeants.mu.png" tvg-chno="4" channel-id="4",OCS Geants FR
 rtp://233.21.50.62:1234
 #EXTINF:-1 tvg-id="13emeRue.fr@SD" tvg-name="13eme Rue" tvg-logo="http://static.epg.best/fr/13Rue.fr.png" tvg-chno="5" channel-id="5",13ème Rue HD FR
 rtp://233.21.50.4:1234
-#EXTINF:-1 tvg-id="SYFY.de@SD" tvg-name="Syfy D" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
+#EXTINF:-1 tvg-id="SYFY.de@SD" tvg-name="Sky Sci-Fi" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
 rtp://233.21.50.5:1234
 #EXTINF:-1 tvg-id="DisneyChannel.fr@SD" tvg-name="Disney Channel F" tvg-logo="http://static.epg.best/fr/DisneyChannel.fr.png" tvg-chno="7" channel-id="7",Disney Channel HD french (fra/eng)
 rtp://233.21.50.11:1234
@@ -112,7 +112,7 @@ rtp://233.32.39.164:1234
 rtp://239.186.64.144:10000
 #EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="29" channel-id="29",8Mont-Blanc HD
 rtp://239.186.70.106:10000
-#EXTINF:-1 tvg-id="TeleSwizz.ch@SD" tvg-name="Teleswizz" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
+#EXTINF:-1 tvg-id="TeleSwizz.ch@SD" tvg-name="CARAC 5" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
 rtp://239.186.68.208:10000
 #EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="35" channel-id="35",BFM BUSINESS
 rtp://239.186.64.146:10000
@@ -170,7 +170,7 @@ rtp://239.186.66.25:10000
 rtp://239.186.70.30:10000
 #EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO" tvg-logo="http://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="Grand Genève TV" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="ici TV Romandie" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
 rtp://239.186.70.133:10000
 #EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="" tvg-chno="72" channel-id="72",LA TELE
 rtp://239.186.64.104:10000
@@ -218,9 +218,9 @@ rtp://239.186.68.244:10000
 rtp://239.186.64.71:10000
 #EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="97" channel-id="97",TV5MONDE EUROPE HD
 rtp://239.186.84.54:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBSM" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
 rtp://239.186.64.150:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBSM" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
 rtp://239.186.70.41:10000
 #EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="" tvg-chno="100" channel-id="100",tvm3
 rtp://239.186.64.98:10000
@@ -261,7 +261,7 @@ rtp://239.186.64.176:10000
 rtp://239.186.68.214:10000
 #EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV" tvg-logo="http://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
 rtp://239.186.64.177:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="132" channel-id="132",THE BOX
+#EXTINF:-1 tvg-id="" tvg-name="The Box" tvg-logo="" tvg-chno="132" channel-id="132",THE BOX
 rtp://239.186.66.142:10000
 #EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN E
 rtp://239.186.66.114:10000
@@ -271,7 +271,7 @@ rtp://239.186.70.90:10000
 rtp://239.186.64.183:10000
 #EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="138" channel-id="138",Channel4 HD
 rtp://239.186.68.40:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show Türk" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
 rtp://239.186.66.115:10000
 #EXTINF:-1 tvg-id="Now70s.uk@SD"  tvg-name="Now 70s",NOW 70s
 rtp://239.186.74.108:10000
@@ -329,11 +329,11 @@ rtp://239.186.64.171:10000
 rtp://239.186.74.14:10000
 #EXTINF:-1 tvg-id="Kerrang.uk" tvg-name="Kerrang! TV UK" tvg-logo="http://static.epg.best/uk/Kerrang.uk.png" tvg-chno="165" channel-id="165",KERRANG!
 rtp://239.186.64.105:10000
-#EXTINF:-1 tvg-id="KissTV.uk" tvg-name="Kiss TV UK" tvg-logo="http://static.epg.best/uk/KissTV.uk.png" tvg-chno="166" channel-id="166",Kiss TV
+#EXTINF:-1 tvg-id="KissTV.uk" tvg-name="Kiss TV" tvg-logo="http://static.epg.best/uk/KissTV.uk.png" tvg-chno="166" channel-id="166",Kiss TV
 rtp://239.186.66.128:10000
 #EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More 4" tvg-logo="http://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World Japan" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
 rtp://239.186.68.172:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="169" channel-id="169",RT Russia Today
 rtp://239.186.66.139:10000
@@ -362,9 +362,9 @@ rtp://239.186.64.142:10000
 rtp://239.186.68.142:10000
 #EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+" tvg-logo="http://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
 rtp://239.186.68.195:10000
-#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="Alpenland TV" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="AW1 TV" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
 rtp://239.186.64.112:10000
-#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="Alpenland TV" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="AW1 TV" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
 rtp://239.186.70.9:10000
 #EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe Serie" tvg-logo="http://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
 rtp://239.186.68.7:10000
@@ -406,7 +406,7 @@ rtp://239.186.70.103:10000
 rtp://239.186.68.216:10000
 #EXTINF:-1 tvg-id="" tvg-name="Deluxe_Music" tvg-logo="http://static.epg.best/de/DeLuxeMusic.de.png" tvg-chno="201" channel-id="201",DELUXE MUSIC
 rtp://239.186.64.132:10000
-#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="DMF" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
 rtp://239.186.66.118:10000
 #EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel D" tvg-logo="http://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel D
 rtp://239.186.64.116:10000
@@ -640,7 +640,7 @@ rtp://239.186.66.202:10000
 rtp://239.186.64.100:10000
 #EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="TV Südostschweiz" tvg-logo="" tvg-chno="322" channel-id="322",TSO Suedostchweiz HD
 rtp://239.186.68.218:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="323" channel-id="323",TV4TNG HD
+#EXTINF:-1 tvg-id="" tvg-name="TV4TNG" tvg-logo="" tvg-chno="323" channel-id="323",TV4TNG HD
 rtp://239.186.70.126:10000
 #EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="TV Oberwallis" tvg-logo="" tvg-chno="324" channel-id="324",TV Oberwallis HD
 rtp://239.186.70.5:10000
@@ -713,7 +713,7 @@ rtp://239.186.66.188:10000
 rtp://239.186.66.187:10000
 #EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2" tvg-logo="http://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Discovery-italia K2 / FAMILY CLUB
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Discovery Turbo" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
 rtp://239.186.74.21:10000
 #EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE" tvg-logo="http://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Discovery-italia NOVE
 rtp://239.186.64.158:10000
@@ -729,7 +729,7 @@ rtp://239.186.74.19:10000
 rtp://239.186.64.49:10000
 #EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
 rtp://239.186.70.7:10000
-#EXTINF:-1 tvg-id="LA7d.it@SD" tvg-name="La 7d" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
+#EXTINF:-1 tvg-id="LA7d.it@SD" tvg-name="La7 Cinema" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
 rtp://239.186.64.164:10000
 #EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo" tvg-logo="http://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="369" channel-id="369",MARCOPOLO.TV
 rtp://239.186.74.20:10000
@@ -797,9 +797,9 @@ rtp://239.186.64.159:10000
 rtp://239.186.64.162:10000
 #EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo" tvg-logo="http://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
 rtp://239.186.68.5:10000
 #EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
@@ -854,9 +854,9 @@ rtp://239.186.70.122:10000
 rtp://239.186.64.209:10000
 #EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show Türk" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
 rtp://239.186.64.200:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show Türk" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
 rtp://239.186.84.36:10000
 #EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="http://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
@@ -886,7 +886,7 @@ rtp://239.186.66.120:10000
 rtp://239.186.66.85:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="443" channel-id="443",ESC1 (Al Masriya)
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT Cosmos" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
 #EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT 1" tvg-logo="" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
@@ -910,7 +910,7 @@ rtp://239.186.66.136:10000
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="http://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK 1" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
 #EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="Rudaw TV" tvg-logo="" tvg-chno="460" channel-id="460",RUDAW HD
 rtp://239.186.68.247:10000

--- a/swisscom-full.m3u
+++ b/swisscom-full.m3u
@@ -1,72 +1,72 @@
 #EXTM3U url-tvg="#EXTM3U url-tvg="https://xmltv.ch/xmltv/xmltv-complet.xml""
 #EXTREM:french
-#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS Un
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS 1" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS Un
 rtp://239.186.64.5:10000
-#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="92" channel-id="92",RTS Un HD
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS 1" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="92" channel-id="92",RTS Un HD
 rtp://239.186.68.3:10000
-#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS Deux
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS 2" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS Deux
 rtp://239.186.64.6:10000
-#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="94" channel-id="94",RTS Deux HD
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS 2" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="94" channel-id="94",RTS Deux HD
 rtp://239.186.68.4:10000
 #EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
 rtp://239.186.64.35:10000
 #EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="100" channel-id="100",TF1 CH HD
 rtp://233.35.254.133:1234
-#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
 rtp://239.186.64.36:10000
-#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="55" channel-id="55",France2 HD
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="55" channel-id="55",France2 HD
 rtp://239.186.68.19:10000
-#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
 rtp://239.186.64.37:10000
-#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="57" channel-id="57",France3 HD
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="57" channel-id="57",France3 HD
 rtp://239.186.70.25:10000
-#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="" channel-id="",France4
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="" channel-id="",France4
 rtp://239.186.64.38:10000
-#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 HD
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 HD
 rtp://239.186.84.55:10000
-#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
 rtp://239.186.64.39:10000
-#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="60" channel-id="60",France5 HD
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="60" channel-id="60",France5 HD
 rtp://239.186.70.27:10000
-#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
 rtp://239.186.64.40:10000
-#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="80" channel-id="80",M6 CH HD
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="80" channel-id="80",M6 CH HD
 rtp://233.35.254.130:1234
-#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH
 rtp://239.186.66.130:10000
-#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH HD
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH HD
 rtp://239.186.68.134:10000
-#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
 rtp://239.186.64.127:10000
-#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="104" channel-id="104",TMC CH HD
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="104" channel-id="104",TMC CH HD
 rtp://239.186.70.37:10000
-#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="83" channel-id="83",NRJ12 CH
+#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ12" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="83" channel-id="83",NRJ12 CH
 rtp://239.186.64.58:10000
-#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="84" channel-id="84",NRJ12 CH HD
+#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ12" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="84" channel-id="84",NRJ12 CH HD
 rtp://239.186.70.33:10000
-#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH (ex NT1)
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH (ex NT1)
 rtp://239.186.64.42:10000
-#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="102" channel-id="102",TFX CH HD (ex NT1 HD)
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="102" channel-id="102",TFX CH HD (ex NT1 HD)
 rtp://239.186.70.34:10000
-#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
 rtp://239.186.64.59:10000
-#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
 rtp://239.186.68.215:10000
-#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
 rtp://239.186.66.24:10000
-#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="114" channel-id="114",W9 CH HD
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="114" channel-id="114",W9 CH HD
 rtp://239.186.70.38:10000
-#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH HD
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="RTL9" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH HD
 rtp://239.186.68.242:10000
-#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte Français" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
 rtp://239.186.64.57:10000
-#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="33" channel-id="33",arte F HD
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte Français" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="33" channel-id="33",arte F HD
 rtp://239.186.68.18:10000
-#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="31" channel-id="31",AB3 CH HD
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="31" channel-id="31",AB3 CH HD
 rtp://239.186.68.33:10000
-#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="OCS Max FR" tvg-logo="http://static.epg.best/fr/OCSMax.fr.png" tvg-chno="1" channel-id="1",OCS Max FR
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="Max TV" tvg-logo="http://static.epg.best/fr/OCSMax.fr.png" tvg-chno="1" channel-id="1",OCS Max FR
 rtp://233.21.50.59:1234
 #EXTINF:-1 tvg-id="OCSCity" tvg-name="OCS City FR" tvg-logo="http://static.epg.best/fr/OCSCity.fr.png" tvg-chno="2" channel-id="2",OCS City FR
 rtp://233.21.50.60:1234
@@ -74,419 +74,419 @@ rtp://233.21.50.60:1234
 rtp://233.21.50.61:1234
 #EXTINF:-1 tvg-id="OcsGeants" tvg-name="Ocs Geants FR" tvg-logo="http://static.epg.best/mu/OcsGeants.mu.png" tvg-chno="4" channel-id="4",OCS Geants FR
 rtp://233.21.50.62:1234
-#EXTINF:-1 tvg-id="13emeRue.fr@SD" tvg-name="13e Rue FR" tvg-logo="http://static.epg.best/fr/13Rue.fr.png" tvg-chno="5" channel-id="5",13ème Rue HD FR
+#EXTINF:-1 tvg-id="13emeRue.fr@SD" tvg-name="13eme Rue" tvg-logo="http://static.epg.best/fr/13Rue.fr.png" tvg-chno="5" channel-id="5",13ème Rue HD FR
 rtp://233.21.50.4:1234
-#EXTINF:-1 tvg-id="SYFY.de@SD" tvg-name="Syfy FR" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
+#EXTINF:-1 tvg-id="SYFY.de@SD" tvg-name="Syfy D" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
 rtp://233.21.50.5:1234
-#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel FR" tvg-logo="http://static.epg.best/fr/DisneyChannel.fr.png" tvg-chno="7" channel-id="7",Disney Channel HD french (fra/eng)
+#EXTINF:-1 tvg-id="DisneyChannel.fr@SD" tvg-name="Disney Channel F" tvg-logo="http://static.epg.best/fr/DisneyChannel.fr.png" tvg-chno="7" channel-id="7",Disney Channel HD french (fra/eng)
 rtp://233.21.50.11:1234
-#EXTINF:-1 tvg-id="131" tvg-name="Disney Junior FR" tvg-logo="http://static.epg.best/fr/DisneyJunior.fr.png" tvg-chno="8" channel-id="8",Disney Junior HD french (fra/eng)
+#EXTINF:-1 tvg-id="DisneyJr.fr@SD" tvg-name="Disney Junior F" tvg-logo="http://static.epg.best/fr/DisneyJunior.fr.png" tvg-chno="8" channel-id="8",Disney Junior HD french (fra/eng)
 rtp://233.21.50.31:1234
-#EXTINF:-1 tvg-id="133" tvg-name="Disney XD FR" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
+#EXTINF:-1 tvg-id="" tvg-name="Disney XD F" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
 rtp://233.21.50.52:1234
-#EXTINF:-1 tvg-id="1068" tvg-name="Disney Cinema FR" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
+#EXTINF:-1 tvg-id="" tvg-name="Disney Cinema F" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
 rtp://233.21.50.70:1234
-#EXTINF:-1 tvg-id="Mangas.fr@SD" tvg-name="Mangas FR" tvg-logo="http://static.epg.best/fr/Mangas.fr.png" tvg-chno="11" channel-id="11",Mangas
+#EXTINF:-1 tvg-id="Mangas.fr@SD" tvg-name="Mangas" tvg-logo="http://static.epg.best/fr/Mangas.fr.png" tvg-chno="11" channel-id="11",Mangas
 rtp://233.21.50.2:1234
-#EXTINF:-1 tvg-id="263" tvg-name="Motorsport TV FR" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
+#EXTINF:-1 tvg-id="" tvg-name="Motorsport TV" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
 rtp://233.21.50.27:1234
-#EXTINF:-1 tvg-id="281" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
+#EXTINF:-1 tvg-id="" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
 rtp://233.21.50.54:1234
 #EXTINF:-1 tvg-id="NatGeoWildFrance" tvg-name="Nat Geo Wild FR" tvg-logo="http://static.epg.best/fr/NatGeoWild.fr.png" tvg-chno="14" channel-id="14",Nat Geo Wild HD French (fra/eng)
 rtp://233.21.50.55:1234
-#EXTINF:-1 tvg-id="TVBreizh.fr@SD" tvg-name="Tv Breizh FR" tvg-logo="http://static.epg.best/fr/TvBreizh.fr.png" tvg-chno="16" channel-id="16",TV Breizh HD
+#EXTINF:-1 tvg-id="TVBreizh.fr@SD" tvg-name="tv breizh" tvg-logo="http://static.epg.best/fr/TvBreizh.fr.png" tvg-chno="16" channel-id="16",TV Breizh HD
 rtp://233.21.50.57:1234
-#EXTINF:-1 tvg-id="UshuaiaTV.fr@SD" tvg-name="Ushuaïa TV FR" tvg-logo="http://static.epg.best/fr/UshuaiaTV.fr.png" tvg-chno="17" channel-id="17",Ushuaia TV HD
+#EXTINF:-1 tvg-id="UshuaiaTV.fr@SD" tvg-name="Ushuaia TV" tvg-logo="http://static.epg.best/fr/UshuaiaTV.fr.png" tvg-chno="17" channel-id="17",Ushuaia TV HD
 rtp://233.21.50.58:1234
-#EXTINF:-1 tvg-id="ParamountChannel.fr" tvg-name="Paramount Channel FR" tvg-logo="http://static.epg.best/fr/ParamountChannel.fr.png" tvg-chno="18" channel-id="18",Paramount Channel HD French
+#EXTINF:-1 tvg-id="ParamountChannel.fr@SD" tvg-name="Paramount F" tvg-logo="http://static.epg.best/fr/ParamountChannel.fr.png" tvg-chno="18" channel-id="18",Paramount Channel HD French
 rtp://233.21.50.126:1234
-#EXTINF:-1 tvg-id="150" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
+#EXTINF:-1 tvg-id="" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
 rtp://233.32.39.142:1234
-#EXTINF:-1 tvg-id="ChassePeche.fr@SD" tvg-name="Chasse et pêche FR" tvg-logo="http://static.epg.best/fr/ChassePeche.fr.png" tvg-chno="21" channel-id="21",Chasse et Peche
+#EXTINF:-1 tvg-id="ChassePeche.fr@SD" tvg-name="Chasse et Peche" tvg-logo="http://static.epg.best/fr/ChassePeche.fr.png" tvg-chno="21" channel-id="21",Chasse et Peche
 rtp://233.32.39.143:1234
-#EXTINF:-1 tvg-id="GolfChannel.fr@SD" tvg-name="Golf Channel US" tvg-logo="http://static.epg.best/us/GolfChannel.us.png" tvg-chno="22" channel-id="22",Golf Channel
+#EXTINF:-1 tvg-id="GolfChannel.fr@SD" tvg-name="Golf Channel" tvg-logo="http://static.epg.best/us/GolfChannel.us.png" tvg-chno="22" channel-id="22",Golf Channel
 rtp://233.32.39.154:1234
-#EXTINF:-1 tvg-id="1039" tvg-name="" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
+#EXTINF:-1 tvg-id="" tvg-name="RMC Sport Access 3" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
 rtp://233.32.39.164:1234
-#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
 rtp://239.186.64.144:10000
-#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="29" channel-id="29",8Mont-Blanc HD
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="29" channel-id="29",8Mont-Blanc HD
 rtp://239.186.70.106:10000
-#EXTINF:-1 tvg-id="TeleSwizz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
+#EXTINF:-1 tvg-id="TeleSwizz.ch@SD" tvg-name="Teleswizz" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
 rtp://239.186.68.208:10000
-#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="35" channel-id="35",BFM BUSINESS
+#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="35" channel-id="35",BFM BUSINESS
 rtp://239.186.64.146:10000
-#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="36" channel-id="36",BFM BUSINESS HD
+#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="36" channel-id="36",BFM BUSINESS HD
 rtp://239.186.70.74:10000
-#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
 rtp://239.186.64.72:10000
-#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="38" channel-id="38",BFMTV CH HD
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="38" channel-id="38",BFMTV CH HD
 rtp://239.186.68.196:10000
-#EXTINF:-1 tvg-id="113" tvg-name="" tvg-logo="" tvg-chno="39" channel-id="39",TV Suisse plus
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="39" channel-id="39",TV Suisse plus
 rtp://239.186.66.239:10000
-#EXTINF:-1 tvg-id="113" tvg-name="" tvg-logo="" tvg-chno="40" channel-id="40",TV Suisse plus HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="40" channel-id="40",TV Suisse plus HD
 rtp://239.186.70.104:10000
-#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="" tvg-logo="" tvg-chno="42" channel-id="42",Canal9
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal 9" tvg-logo="" tvg-chno="42" channel-id="42",Canal9
 rtp://239.186.64.108:10000
-#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="" tvg-logo="" tvg-chno="43" channel-id="43",Canal9 HD
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal 9" tvg-logo="" tvg-chno="43" channel-id="43",Canal9 HD
 rtp://239.186.68.144:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
 rtp://239.186.64.106:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="45" channel-id="45",CanalAlpha JU HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="45" channel-id="45",CanalAlpha JU HD
 rtp://239.186.68.193:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
 rtp://239.186.64.92:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="47" channel-id="47",Canal Alpha NE HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="47" channel-id="47",Canal Alpha NE HD
 rtp://239.186.68.194:10000
-#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="50" channel-id="50",CSTAR
+#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CSTAR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="50" channel-id="50",CSTAR
 rtp://239.186.66.26:10000
-#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="51" channel-id="51",CSTAR HD
+#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CSTAR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="51" channel-id="51",CSTAR HD
 rtp://239.186.70.24:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
 rtp://239.186.64.151:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="53" channel-id="53",euronews. F HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="53" channel-id="53",euronews. F HD
 rtp://239.186.70.148:10000
-#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="LEquipe21 FR" tvg-logo="http://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="474" channel-id="474",EQUIPE HD
+#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="L'Equipe" tvg-logo="http://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="474" channel-id="474",EQUIPE HD
 rtp://239.186.79.78:10000
-#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
 rtp://239.186.66.225:10000
-#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="" channel-id="",franceinfo HD
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="" channel-id="",franceinfo HD
 rtp://239.186.70.121:10000
-#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
 rtp://239.186.64.41:10000
-#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24 HD
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24 HD
 rtp://239.186.70.125:10000
-#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
 rtp://239.186.66.23:10000
-#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="65" channel-id="65",gulli HD
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="65" channel-id="65",gulli HD
 rtp://239.186.70.29:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24 News FR" tvg-logo="" tvg-chno="66" channel-id="66",i24 NEWS F
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="" tvg-chno="66" channel-id="66",i24 NEWS F
 rtp://239.186.66.174:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24 News FR" tvg-logo="" tvg-chno="67" channel-id="67",i24 NEWS F HD
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
-#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNEWS" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
 rtp://239.186.66.25:10000
-#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="69" channel-id="69",CNEWS HD
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNEWS" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="69" channel-id="69",CNEWS HD
 rtp://239.186.70.30:10000
-#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="http://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO" tvg-logo="http://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="Grand Genève TV" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
 rtp://239.186.70.133:10000
-#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="72" channel-id="72",LA TELE
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="" tvg-chno="72" channel-id="72",LA TELE
 rtp://239.186.64.104:10000
-#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
-#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE FR HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE FR HD
 rtp://239.186.70.161:10000
-#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Top Calcio 24" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="75" channel-id="75",LCI HD La Chaine Info HD
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Top Calcio 24" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="75" channel-id="75",LCI HD La Chaine Info HD
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",lemanbleu
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Léman Bleu Télévision" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",lemanbleu
 rtp://239.186.64.89:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="77" channel-id="77",lemanbleu HD
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Léman Bleu Télévision" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="77" channel-id="77",lemanbleu HD
 rtp://239.186.70.39:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="78" channel-id="78",lfm TV HD
 rtp://239.186.70.11:10000
-#EXTINF:-1 tvg-id="One.de@SD" tvg-name="" tvg-logo="" tvg-chno="87" channel-id="79",One tv CH HD
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One" tvg-logo="" tvg-chno="87" channel-id="79",One tv CH HD
 rtp://239.186.70.12:10000
-#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv dieu tv
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="Max TV" tvg-logo="" tvg-chno="81" channel-id="81",maxtv dieu tv
 rtp://239.186.64.102:10000
-#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="82" channel-id="82",maxtv dieu tv HD
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="Max TV" tvg-logo="" tvg-chno="82" channel-id="82",maxtv dieu tv HD
 rtp://239.186.68.199:10000
-#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
 rtp://239.186.66.198:10000
-#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="86" channel-id="86",nrtv HD
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV" tvg-logo="" tvg-chno="86" channel-id="86",nrtv HD
 rtp://239.186.70.66:10000
 #EXTINF:-1 tvg-id="RougeTV" tvg-name="Rouge TV CH" tvg-logo="http://static.epg.best/ch/RougeTV.ch.png" tvg-chno="88" channel-id="88",rougeTV
 rtp://239.186.64.145:10000
 #EXTINF:-1 tvg-id="RougeTV" tvg-name="Rouge TV CH" tvg-logo="http://static.epg.best/ch/RougeTV.ch.png" tvg-chno="89" channel-id="89",rougeTV HD
 rtp://239.186.68.253:10000
-#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="RTL9" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH
 rtp://239.186.64.155:10000
-#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="91" channel-id="91",RTL9 CH HD
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="RTL9" tvg-logo="" tvg-chno="91" channel-id="91",RTL9 CH HD
 rtp://239.186.68.242:10000
-#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="" tvg-logo="" tvg-chno="92" channel-id="92",GENEVE REGION TELEVISION
+#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="Genève Région Television/TéléVersoix" tvg-logo="" tvg-chno="92" channel-id="92",GENEVE REGION TELEVISION
 rtp://239.186.64.69:10000
-#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="" tvg-logo="" tvg-chno="93" channel-id="93",GENEVE REGION TELEVISION HD
+#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="Genève Région Television/TéléVersoix" tvg-logo="" tvg-chno="93" channel-id="93",GENEVE REGION TELEVISION HD
 rtp://239.186.70.155:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="" tvg-logo="" tvg-chno="94" channel-id="94",blue Zoom F
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="" tvg-chno="94" channel-id="94",blue Zoom F
 rtp://239.186.64.111:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="" tvg-logo="" tvg-chno="95" channel-id="95",blue Zoom F HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="" tvg-chno="95" channel-id="95",blue Zoom F HD
 rtp://239.186.68.244:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="96" channel-id="96",TV5MONDE EUROPE
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="96" channel-id="96",TV5MONDE EUROPE
 rtp://239.186.64.71:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="97" channel-id="97",TV5MONDE EUROPE HD
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="97" channel-id="97",TV5MONDE EUROPE HD
 rtp://239.186.84.54:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
 rtp://239.186.64.150:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
 rtp://239.186.70.41:10000
-#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="" tvg-logo="" tvg-chno="100" channel-id="100",tvm3
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="" tvg-chno="100" channel-id="100",tvm3
 rtp://239.186.64.98:10000
-#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="" tvg-logo="" tvg-chno="101" channel-id="101",tvm3 HD
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="" tvg-chno="101" channel-id="101",tvm3 HD
 rtp://239.186.70.21:10000
-#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="" tvg-logo="" tvg-chno="102" channel-id="102",TV Onex HD
+#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="TV Onex" tvg-logo="" tvg-chno="102" channel-id="102",TV Onex HD
 rtp://239.186.70.132:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="115" channel-id="115",Al Jazeera E
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="115" channel-id="115",Al Jazeera E
 rtp://239.186.64.173:10000
-#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",Al Jazeera E HD
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",Al Jazeera E HD
 rtp://239.186.68.171:10000
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC One
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC One
 rtp://239.186.64.51:10000
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="119" channel-id="119",BBC One HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="119" channel-id="119",BBC One HD
 rtp://239.186.68.43:10000
-#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC Two
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC Two" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC Two
 rtp://239.186.64.165:10000
-#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="121" channel-id="121",BBC Two HD
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC Two" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="121" channel-id="121",BBC Two HD
 rtp://239.186.68.41:10000
-#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC
 rtp://239.186.64.166:10000
-#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="123" channel-id="123",BBC CBBC HD
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="123" channel-id="123",BBC CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
+#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
 rtp://239.186.64.52:10000
-#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
-#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
-#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="127" channel-id="127",BBC CBeebies HD / BBC Four HD
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="127" channel-id="127",BBC CBeebies HD / BBC Four HD
 rtp://239.186.68.152:10000
-#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC News UK" tvg-logo="http://static.epg.best/uk/BBCNews.uk.png" tvg-chno="128" channel-id="128",BBC News HD
+#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC News" tvg-logo="http://static.epg.best/uk/BBCNews.uk.png" tvg-chno="128" channel-id="128",BBC News HD
 rtp://239.186.68.160:10000
-#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="129" channel-id="129",BBC World News
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="129" channel-id="129",BBC World News
 rtp://239.186.64.176:10000
-#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="130" channel-id="130",BBC World News HD
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="130" channel-id="130",BBC World News HD
 rtp://239.186.68.214:10000
-#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="http://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV" tvg-logo="http://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
 rtp://239.186.64.177:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="132" channel-id="132",THE BOX
 rtp://239.186.66.142:10000
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN E
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN E
 rtp://239.186.66.114:10000
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="136" channel-id="136",CGTN E HD
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="136" channel-id="136",CGTN E HD
 rtp://239.186.70.90:10000
-#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
 rtp://239.186.64.183:10000
-#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="138" channel-id="138",Channel4 HD
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="138" channel-id="138",Channel4 HD
 rtp://239.186.68.40:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Chart Show UK" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
 rtp://239.186.66.115:10000
-#EXTINF:-1 tvg-id="Now70s.uk@SD" ,NOW 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD"  tvg-name="Now 70s",NOW 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 tvg-id="Now80s.uk@SD" ,NOW 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD"  tvg-name="Now 80s",NOW 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="" tvg-logo="" tvg-chno="140" channel-id="140",NOW 90s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s" tvg-logo="" tvg-chno="140" channel-id="140",NOW 90s
 rtp://239.186.66.133:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="http://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="141" channel-id="141",clubland
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV" tvg-logo="http://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="141" channel-id="141",clubland
 rtp://239.186.66.116:10000
 #EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC UK
 rtp://239.186.64.167:10000
 #EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="143" channel-id="143",CNBC UK HD
 rtp://239.186.70.224:10000
-#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
 rtp://239.186.64.175:10000
-#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="145" channel-id="145",CNN International HD
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="145" channel-id="145",CNN International HD
 rtp://239.186.70.23:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="207" channel-id="207",DW Deutsche Welle English
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="902" tvg-name="Drama UK" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
+#EXTINF:-1 tvg-id="" tvg-name="Drama" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
 rtp://239.186.66.140:10000
-#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="http://static.epg.best/uk/E4.uk.png" tvg-chno="147" channel-id="147",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4" tvg-logo="http://static.epg.best/uk/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews. E
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews. E
 rtp://239.186.64.178:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="149" channel-id="149",euronews. E HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="149" channel-id="149",euronews. E HD
 rtp://239.186.70.105:10000
-#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
+#EXTINF:-1 tvg-id="FashionTVEurope.fr@SD" tvg-name="Fashion TV" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
 rtp://239.186.64.174:10000
-#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="151" channel-id="151",Fashion TV HD
+#EXTINF:-1 tvg-id="FashionTVEurope.fr@SD" tvg-name="Fashion TV" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="151" channel-id="151",Fashion TV HD
 rtp://239.186.70.200:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="http://static.epg.best/uk/Film4.uk.png" tvg-chno="152" channel-id="152",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="153" channel-id="153",Five
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="153" channel-id="153",Five
 rtp://239.186.64.184:10000
-#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="154" channel-id="154",Five HD
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="154" channel-id="154",Five HD
 rtp://239.186.70.151:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="http://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="http://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="" tvg-logo="" tvg-chno="157" channel-id="157",i24 NEWS E
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="" tvg-chno="157" channel-id="157",i24 NEWS E
 rtp://239.186.66.126:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="" tvg-logo="" tvg-chno="158" channel-id="158",i24 NEWS E HD
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="" tvg-chno="158" channel-id="158",i24 NEWS E HD
 rtp://239.186.68.140:10000
-#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="159" channel-id="159",itv
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="159" channel-id="159",itv
 rtp://239.186.64.169:10000
-#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="160" channel-id="160",itv HD
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="160" channel-id="160",itv HD
 rtp://239.186.68.42:10000
-#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="http://static.epg.best/uk/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2" tvg-logo="http://static.epg.best/uk/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
 rtp://239.186.64.170:10000
-#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="http://static.epg.best/uk/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3" tvg-logo="http://static.epg.best/uk/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
 rtp://239.186.64.180:10000
-#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="http://static.epg.best/uk/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4" tvg-logo="http://static.epg.best/uk/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
 rtp://239.186.64.171:10000
-#EXTINF:-1 tvg-id="ITVBe.uk@SD" tvg-name="ITVBe UK" tvg-logo="http://static.epg.best/uk/ITVBe.uk.png" tvg-chno="164" channel-id="164",itv Be.
+#EXTINF:-1 tvg-id="ITVBe.uk@SD" tvg-name="ITVBe" tvg-logo="http://static.epg.best/uk/ITVBe.uk.png" tvg-chno="164" channel-id="164",itv Be.
 rtp://239.186.74.14:10000
 #EXTINF:-1 tvg-id="Kerrang.uk" tvg-name="Kerrang! TV UK" tvg-logo="http://static.epg.best/uk/Kerrang.uk.png" tvg-chno="165" channel-id="165",KERRANG!
 rtp://239.186.64.105:10000
 #EXTINF:-1 tvg-id="KissTV.uk" tvg-name="Kiss TV UK" tvg-logo="http://static.epg.best/uk/KissTV.uk.png" tvg-chno="166" channel-id="166",Kiss TV
 rtp://239.186.66.128:10000
-#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="http://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More 4" tvg-logo="http://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World JP" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
 rtp://239.186.68.172:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="169" channel-id="169",RT Russia Today
 rtp://239.186.66.139:10000
-#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="http://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News International" tvg-logo="http://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="1410" tvg-name="" tvg-logo="" tvg-chno="" channel-id="",5Spike
+#EXTINF:-1 tvg-id="" tvg-name="5Spike" tvg-logo="" tvg-chno="" channel-id="",5Spike
 rtp://239.186.66.244:10000
-#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA" tvg-logo="http://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament UK" tvg-logo="http://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC Parliament
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament" tvg-logo="http://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC Parliament
 rtp://239.186.74.25:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="http://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America" tvg-logo="http://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America
 rtp://239.186.66.243:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
+#EXTINF:-1 tvg-id="3Plus.ch@SD" tvg-name="3+" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
 rtp://239.186.64.56:10000
-#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
+#EXTINF:-1 tvg-id="3Plus.ch@SD" tvg-name="3+" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
 rtp://239.186.68.14:10000
 #EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
 rtp://239.186.64.55:10000
 #EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
 rtp://233.35.254.209:1234
-#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
+#EXTINF:-1 tvg-id="4Plus.ch@SD" tvg-name="4+" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
 rtp://239.186.64.142:10000
-#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
+#EXTINF:-1 tvg-id="4Plus.ch@SD" tvg-name="4+" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
 rtp://239.186.68.142:10000
-#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+ CH" tvg-logo="http://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
+#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+" tvg-logo="http://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
 rtp://239.186.68.195:10000
-#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="Alpenland TV" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
 rtp://239.186.64.112:10000
-#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="Alpenland TV" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
 rtp://239.186.70.9:10000
-#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe DE" tvg-logo="http://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
+#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe Serie" tvg-logo="http://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
 rtp://239.186.68.7:10000
-#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="" tvg-logo="" tvg-chno="182" channel-id="182",ARD1 Das Erste
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="" tvg-chno="182" channel-id="182",ARD1 Das Erste
 rtp://239.186.64.11:10000
-#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="" tvg-logo="" tvg-chno="183" channel-id="183",ARD1 Das Erste HD
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="" tvg-chno="183" channel-id="183",ARD1 Das Erste HD
 rtp://239.186.68.9:10000
-#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="195",ARD alpha
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD-alpha" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="195",ARD alpha
 rtp://239.186.64.119:10000
-#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="196",ARD alpha HD
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD-alpha" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="196",ARD alpha HD
 rtp://239.186.70.194:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="185" channel-id="185",ARD one
 rtp://239.186.64.121:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="186" channel-id="186",ARD one HD
 rtp://239.186.68.154:10000
-#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="187" channel-id="187",arte D
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte Deutsch" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="187" channel-id="187",arte D
 rtp://239.186.64.23:10000
-#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="188" channel-id="188",arte D HD
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte Deutsch" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="188" channel-id="188",arte D HD
 rtp://239.186.68.11:10000
-#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV HD
+#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="Auftanken TV" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV HD
 rtp://239.186.70.117:10000
-#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="190" channel-id="190",BEATZ HD / radio Pilatus HD
+#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="Radio Pilatus TV" tvg-logo="" tvg-chno="190" channel-id="190",BEATZ HD / radio Pilatus HD
 rtp://239.186.68.104:10000
-#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
 rtp://239.186.64.131:10000
-#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
 rtp://239.186.68.148:10000
-#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Regio TV Bodensee DE" tvg-logo="http://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
+#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Bodensee TV" tvg-logo="http://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
 rtp://239.186.68.143:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
 rtp://239.186.64.26:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
 rtp://239.186.68.26:10000
-#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="" tvg-logo="" tvg-chno="198" channel-id="198",Channel55 D
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5" tvg-logo="" tvg-chno="198" channel-id="198",Channel55 D
 rtp://239.186.66.238:10000
-#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="" tvg-logo="" tvg-chno="199" channel-id="199",Channel55 D HD
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5" tvg-logo="" tvg-chno="199" channel-id="199",Channel55 D HD
 rtp://239.186.70.103:10000
-#EXTINF:-1 tvg-id="116" tvg-name="" tvg-logo="" tvg-chno="200" channel-id="200",Davos Klosters HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="200" channel-id="200",Davos Klosters HD
 rtp://239.186.68.216:10000
-#EXTINF:-1 tvg-id="120" tvg-name="Deluxe Music DE" tvg-logo="http://static.epg.best/de/DeLuxeMusic.de.png" tvg-chno="201" channel-id="201",DELUXE MUSIC
+#EXTINF:-1 tvg-id="" tvg-name="Deluxe_Music" tvg-logo="http://static.epg.best/de/DeLuxeMusic.de.png" tvg-chno="201" channel-id="201",DELUXE MUSIC
 rtp://239.186.64.132:10000
-#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
 rtp://239.186.66.118:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="http://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel D
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel D" tvg-logo="http://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel D
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="1068" tvg-name="Disney Cinema DE" tvg-logo="http://static.epg.best/de/DisneyCinema.de.png" tvg-chno="156" channel-id="156",Disney Cinema D
+#EXTINF:-1 tvg-id="" tvg-name="Disney Cinema F" tvg-logo="http://static.epg.best/de/DisneyCinema.de.png" tvg-chno="156" channel-id="156",Disney Cinema D
 rtp://239.186.64.218:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="Dmax DE" tvg-logo="http://static.epg.best/de/DMax.de.png" tvg-chno="204" channel-id="204",DMAX Schweiz
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="http://static.epg.best/de/DMax.de.png" tvg-chno="204" channel-id="204",DMAX Schweiz
 rtp://239.186.64.34:10000
-#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="205" channel-id="205",More Than Sport
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="More Than Sports TV" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="205" channel-id="205",More Than Sport
 rtp://239.186.66.241:10000
-#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="206" channel-id="206",More Than Sport HD
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="More Than Sports TV" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="206" channel-id="206",More Than Sport HD
 rtp://239.186.70.28:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="207" channel-id="207",DW Deutsche Welle Deutsch
 rtp://239.186.74.26:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
 rtp://239.186.64.137:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
 rtp://239.186.70.101:10000
-#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="folx.tv" tvg-logo="" tvg-chno="212" channel-id="212",Folx
 rtp://239.186.66.197:10000
-#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx HD
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="folx.tv" tvg-logo="" tvg-chno="212" channel-id="212",Folx HD
 rtp://239.186.68.121:10000/
-#EXTINF:-1 tvg-id="1069" tvg-name="" tvg-logo="" tvg-chno="473" channel-id="473",FOX D
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="473" channel-id="473",FOX D
 rtp://239.186.64.213:10000
 #EXTINF:-1 tvg-id="GoTV.at" tvg-name="Go TV" tvg-logo="http://static.epg.best/at/GoTV.at.png" tvg-chno="213" channel-id="213",gotv
 rtp://239.186.64.141:10000
-#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="214" channel-id="214",HopeChannel
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope TV" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="214" channel-id="214",HopeChannel
 rtp://239.186.64.115:10000
-#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="215" channel-id="215",HopeChannel HD
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope TV" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="215" channel-id="215",HopeChannel HD
 rtp://239.186.68.251:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
 rtp://239.186.64.28:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
 rtp://239.186.68.156:10000
-#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE24 DE" tvg-logo="http://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE24
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE" tvg-logo="http://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE24
 rtp://239.186.64.123:10000
 #EXTINF:-1 tvg-id="Insight.uk" tvg-name="Insight UK" tvg-logo="http://static.epg.best/uk/Insight.uk.png" tvg-chno="219" channel-id="219",Insight.tv HD
 rtp://239.186.70.75:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="http://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins
 rtp://239.186.64.20:10000
-#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
 rtp://239.186.64.109:10000
-#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
 rtp://239.186.68.145:10000
-#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKa" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
 rtp://239.186.64.31:10000
-#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKa" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
 rtp://239.186.68.28:10000
-#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="http://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
+#EXTINF:-1 tvg-id="KTV.at@SD" tvg-name="K-TV" tvg-logo="http://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
 rtp://239.186.64.133:10000
-#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="221" channel-id="221",LOLY
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="221" channel-id="221",LOLY
 rtp://239.186.66.231:10000
-#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="222" channel-id="222",LOLY HD
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="222" channel-id="222",LOLY HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
-#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
-#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie TV
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="" tvg-chno="231" channel-id="231",Melodie TV
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="232" channel-id="232",MTV CH
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="232" channel-id="232",MTV CH
 rtp://239.186.64.32:10000
-#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="233" channel-id="233",MTV CH HD
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="233" channel-id="233",MTV CH HD
 rtp://239.186.68.174:10000
-#EXTINF:-1 tvg-id="272" tvg-name="Music 24 IL" tvg-logo="http://static.epg.best/il/Music24.il.png" tvg-chno="234" channel-id="234",musig24 HD
+#EXTINF:-1 tvg-id="" tvg-name="Music 24 IL" tvg-logo="http://static.epg.best/il/Music24.il.png" tvg-chno="234" channel-id="234",musig24 HD
 rtp://239.186.68.207:10000
-#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="http://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="http://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
-#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="238" channel-id="238",nick schweiz
 rtp://239.186.64.186:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="239" channel-id="239",nick schweiz HD
 rtp://239.186.68.175:10000
-#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="http://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="Nitro" tvg-logo="http://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
-#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
 rtp://239.186.64.29:10000
-#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="242" channel-id="242",ntv HD
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="242" channel-id="242",ntv HD
 rtp://239.186.68.146:10000
 #EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="http://static.epg.best/at/ORF1.at.png" tvg-chno="243" channel-id="243",ORF1
 rtp://239.186.64.13:10000
@@ -500,439 +500,439 @@ rtp://239.186.68.13:10000
 rtp://239.186.64.86:10000
 #EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="http://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
 rtp://239.186.64.65:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
 rtp://239.186.68.30:10000
-#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro 7 DE" tvg-logo="http://static.epg.best/de/Pro7.de.png" tvg-chno="251" channel-id="251",Pro7
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="http://static.epg.best/de/Pro7.de.png" tvg-chno="251" channel-id="251",Pro7
 rtp://239.186.64.19:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="254" channel-id="254",Puls aCHT HD
 rtp://239.186.68.191:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="" channel-id="254",QS24 QantiSana HD
 rtp://233.35.254.211:1234
-#EXTINF:-1 tvg-id="R9.at@SD" tvg-name="" tvg-logo="" tvg-chno="255" channel-id="255",R9 Oesterreich HD
+#EXTINF:-1 tvg-id="R9.at@SD" tvg-name="R9 Österreich" tvg-logo="" tvg-chno="255" channel-id="255",R9 Oesterreich HD
 rtp://239.186.68.248:10000
-#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
+#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
 rtp://239.186.64.126:10000
-#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
+#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
 rtp://239.186.68.157:10000
-#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="Regio TV DE" tvg-logo="http://static.epg.best/de/RegioTV.de.png" tvg-chno="258" channel-id="258",regioTVplus HD
+#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="regioTVplus" tvg-logo="http://static.epg.best/de/RegioTV.de.png" tvg-chno="258" channel-id="258",regioTVplus HD
 rtp://239.186.70.40:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
+#EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH HD
+#EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH HD
 rtp://233.35.254.237:1234
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
+#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
+#EXTINF:-1 tvg-id="" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1 CH" tvg-logo="http://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
+#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1" tvg-logo="http://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
-#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="http://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="SAT.1" tvg-logo="http://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
 rtp://239.186.64.18:10000
-#EXTINF:-1 tvg-id="378" tvg-name="" tvg-logo="" tvg-chno="267" channel-id="267",Schweiz5
+#EXTINF:-1 tvg-id="" tvg-name="Schweiz 5" tvg-logo="" tvg-chno="267" channel-id="267",Schweiz5
 rtp://239.186.64.101:10000
-#EXTINF:-1 tvg-id="378" tvg-name="" tvg-logo="" tvg-chno="268" channel-id="268",Schweiz5 HD
+#EXTINF:-1 tvg-id="" tvg-name="Schweiz 5" tvg-logo="" tvg-chno="268" channel-id="268",Schweiz5 HD
 rtp://239.186.68.245:10000
 #EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV DEUTSCHLAND CH
 rtp://239.186.64.136:10000
 #EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="270" channel-id="270",ServusTV DEUTSCHLAND CH HD
 rtp://233.35.254.129:1234
-#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
 rtp://239.186.66.146:10000
-#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="272" channel-id="272",SessionNationalrat HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="272" channel-id="272",SessionNationalrat HD
 rtp://239.186.70.127:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="273" channel-id="273",SessionStaenderat
 rtp://239.186.64.124:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="274" channel-id="274",SessionStaendenrat HD
 rtp://239.186.70.128:10000
-#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf - Schaffhauser Fernsehen" tvg-logo="" tvg-chno="276" channel-id="276",SHf
 rtp://239.186.64.97:10000
-#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="277" channel-id="277",SHf HD
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf - Schaffhauser Fernsehen" tvg-logo="" tvg-chno="277" channel-id="277",SHf HD
 rtp://239.186.68.139:10000
-#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="http://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="sixx" tvg-logo="http://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
 rtp://239.186.64.70:10000
-#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",sport1 CH
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport1" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",sport1 CH
 rtp://239.186.64.64:10000
-#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",sport1 CH HD
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport1" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",sport1 CH HD
 rtp://239.186.68.159:10000
-#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
 rtp://239.186.64.2:10000
-#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 HD
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 HD
 rtp://239.186.68.1:10000
-#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
 rtp://239.186.64.3:10000
-#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 HD SRF zwei HD
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 HD SRF zwei HD
 rtp://239.186.68.2:10000
-#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF info" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
 rtp://239.186.64.4:10000
-#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info HD
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF info" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info HD
 rtp://239.186.68.202:10000
-#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
 rtp://239.186.64.87:10000
-#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",Star TV HD
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",Star TV HD
 rtp://239.186.68.188:10000
-#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="289" channel-id="289",GAMETV HD
+#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="Game TV" tvg-logo="" tvg-chno="289" channel-id="289",GAMETV HD
 rtp://239.186.70.10:10000
-#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL DE" tvg-logo="http://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",SUPER RTL
+#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL" tvg-logo="http://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",SUPER RTL
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="" tvg-logo="" tvg-chno="291" channel-id="291",Swiss 1 HD
+#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="SWISS1" tvg-logo="" tvg-chno="291" channel-id="291",Swiss 1 HD
 rtp://239.186.68.97:10000
-#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="292" channel-id="292",SWR >>
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="292" channel-id="292",SWR >>
 rtp://239.186.64.27:10000
-#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >> HD
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >> HD
 rtp://239.186.68.25:10000
-#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="294" channel-id="294",Tagesschau24
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau24" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="294" channel-id="294",Tagesschau24
 rtp://239.186.64.120:10000
-#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24 HD
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau24" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24 HD
 rtp://239.186.68.161:10000
-#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="296" channel-id="296",Tele1
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele 1" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="296" channel-id="296",Tele1
 rtp://239.186.64.91:10000
-#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1 HD
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele 1" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1 HD
 rtp://239.186.68.176:10000
-#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="298" channel-id="298",TELE5
+#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="298" channel-id="298",TELE5
 rtp://239.186.64.22:10000
-#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="299" channel-id="299",TELE5 HD
+#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="299" channel-id="299",TELE5 HD
 rtp://239.186.64.22:10000
-#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",TELE BAERN
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Bärn" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",TELE BAERN
 rtp://239.186.64.60:10000
-#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",TELE BAERN HD
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Bärn" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",TELE BAERN HD
 rtp://239.186.68.38:10000
-#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="" tvg-logo="" tvg-chno="302" channel-id="302",TeleBielingue
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="Tele Bielingue" tvg-logo="" tvg-chno="302" channel-id="302",TeleBielingue
 rtp://239.186.64.95:10000
-#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="" tvg-logo="" tvg-chno="303" channel-id="303",TeleBielingue HD
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="Tele Bielingue" tvg-logo="" tvg-chno="303" channel-id="303",TeleBielingue HD
 rtp://239.186.70.82:10000
-#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="" tvg-logo="" tvg-chno="304" channel-id="304",TELE D HD
+#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="Tele D" tvg-logo="" tvg-chno="304" channel-id="304",TELE D HD
 rtp://239.186.68.217:10000
-#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
 rtp://239.186.64.90:10000
-#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
 rtp://239.186.68.102:10000
-#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
 rtp://239.186.64.96:10000
-#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
 rtp://239.186.68.252:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
 rtp://239.186.64.103:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="310" channel-id="310",TELEZ HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="" tvg-chno="310" channel-id="310",TELEZ HD
 rtp://239.186.68.205:10000
-#EXTINF:-1 tvg-id="TeleZentralschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="311" channel-id="311",Tele Zentralschweiz
+#EXTINF:-1 tvg-id="TeleZentralschweiz.ch@SD" tvg-name="Tele Zentralschweiz" tvg-logo="" tvg-chno="311" channel-id="311",Tele Zentralschweiz
 rtp://239.186.68.166:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",TELE ZURI
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",TELE ZURI
 rtp://239.186.64.9:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
 rtp://239.186.68.189:10000
-#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Telebasel" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
 rtp://239.186.64.88:10000
-#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Telebasel" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
 rtp://239.186.68.206:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="316" channel-id="316",blue zoom D
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="316" channel-id="316",blue zoom D
 rtp://239.186.66.129:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="317" channel-id="317",blue zoom D HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="317" channel-id="317",blue zoom D HD
 rtp://239.186.68.155:10000
-#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="318" channel-id="318",TLC CH
+#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="318" channel-id="318",TLC CH
 rtp://239.186.66.175:10000
-#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="319" channel-id="319",TLC CH HD
+#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="319" channel-id="319",TLC CH HD
 rtp://239.186.70.67:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="http://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo Plus" tvg-logo="http://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
-#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="321" channel-id="321",TSO Suedostchweiz
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="TV Südostschweiz" tvg-logo="" tvg-chno="321" channel-id="321",TSO Suedostchweiz
 rtp://239.186.64.100:10000
-#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="322" channel-id="322",TSO Suedostchweiz HD
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="TV Südostschweiz" tvg-logo="" tvg-chno="322" channel-id="322",TSO Suedostchweiz HD
 rtp://239.186.68.218:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="323" channel-id="323",TV4TNG HD
 rtp://239.186.70.126:10000
-#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="" tvg-logo="" tvg-chno="324" channel-id="324",TV Oberwallis HD
+#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="TV Oberwallis" tvg-logo="" tvg-chno="324" channel-id="324",TV Oberwallis HD
 rtp://239.186.70.5:10000
-#EXTINF:-1 tvg-id="TVRheintal.ch@SD" tvg-name="" tvg-logo="" tvg-chno="325" channel-id="325",TV Rheintal
+#EXTINF:-1 tvg-id="TVRheintal.ch@SD" tvg-name="TV Rheintal" tvg-logo="" tvg-chno="325" channel-id="325",TV Rheintal
 rtp://239.186.64.93:10000
-#EXTINF:-1 tvg-id="1910" tvg-name="TV24 CH" tvg-logo="http://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
+#EXTINF:-1 tvg-id="TV24.ch@SD" tvg-name="TV24" tvg-logo="http://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
 rtp://239.186.68.190:10000
 #EXTINF:-1 tvg-id="TV25.ch" tvg-name="TV 25 CH" tvg-logo="http://static.epg.best/ch/TV25.ch.png" tvg-chno="327" channel-id="327",TV25 HD
 rtp://239.186.70.20:10000
-#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
 rtp://239.186.64.94:10000
-#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
 rtp://239.186.70.4:10000
-#EXTINF:-1 tvg-id="917" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="330" channel-id="330",vision tv
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="330" channel-id="330",vision tv
 rtp://239.186.64.62:10000
-#EXTINF:-1 tvg-id="917" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="331" channel-id="331",vision tv HD
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="331" channel-id="331",vision tv HD
 rtp://239.186.70.65:10000
-#EXTINF:-1 tvg-id="ComedyCentral.de@SD" tvg-name="Comedy Central DE" tvg-logo="http://static.epg.best/de/ComedyCentral.de.png" tvg-chno="332" channel-id="332",Comedy Central
+#EXTINF:-1 tvg-id="ComedyCentral.de@SD" tvg-name="Comedy Central" tvg-logo="http://static.epg.best/de/ComedyCentral.de.png" tvg-chno="332" channel-id="332",Comedy Central
 rtp://239.186.64.61:10000
-#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="http://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="http://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
-#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
-#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="" tvg-logo="" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder DE" tvg-logo="http://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV HD
+#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder TV" tvg-logo="http://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV HD
 rtp://239.186.68.198:10000
-#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="Wetter.com TV DE" tvg-logo="http://static.epg.best/de/Wetterfernsehen.de.png" tvg-chno="338" channel-id="338",wetter.tv HD
+#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="Wetter.TV" tvg-logo="http://static.epg.best/de/Wetterfernsehen.de.png" tvg-chno="338" channel-id="338",wetter.tv HD
 rtp://239.186.70.119:10000
-#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
 rtp://239.186.64.12:10000
-#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
 rtp://239.186.68.10:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDFinfo" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
 rtp://239.186.64.118:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDFinfo" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
 rtp://239.186.68.32:10000
-#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDFneo" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
 rtp://239.186.64.66:10000
-#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDFneo" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
 rtp://239.186.68.31:10000
-#EXTINF:-1 tvg-id="1031" tvg-name="Zee One DE" tvg-logo="http://static.epg.best/de/ZeeOne.de.png" tvg-chno="345" channel-id="345",ZEEONE HD
+#EXTINF:-1 tvg-id="" tvg-name="Zee One" tvg-logo="http://static.epg.best/de/ZeeOne.de.png" tvg-chno="345" channel-id="345",ZEEONE HD
 rtp://239.186.70.70:10000
 #EXTREM:italian
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="346" channel-id="346",7G Telecity
 rtp://239.186.74.23:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="347" channel-id="347",ALICE
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="Antenna 3" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
 rtp://239.186.74.18:10000
-#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="http://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing I" tvg-logo="http://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
 rtp://239.186.64.74:10000
-#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="Canale Italia" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="http://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",cartoonito
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito F" tvg-logo="http://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",cartoonito
 rtp://239.186.66.176:10000
-#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="http://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo" tvg-logo="http://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
 rtp://239.186.64.76:10000
-#EXTINF:-1 tvg-id="1381" tvg-name="CineSony IT" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
+#EXTINF:-1 tvg-id="" tvg-name="CineSony IT" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
 rtp://239.186.74.22:10000
-#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",Class TV Moda
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="Class TV Moda" tvg-logo="" tvg-chno="354" channel-id="354",Class TV Moda
 rtp://239.186.66.189:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="http://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Discovery-italia DMAX
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="http://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Discovery-italia DMAX
 rtp://239.186.66.110:10000
-#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="http://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Discovery-italia Frisbee /FAMILY CLUB
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee" tvg-logo="http://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Discovery-italia Frisbee /FAMILY CLUB
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="http://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Discovery-italia Giallo
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo" tvg-logo="http://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Discovery-italia Giallo
 rtp://239.186.66.187:10000
-#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="http://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Discovery-italia K2 / FAMILY CLUB
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2" tvg-logo="http://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Discovery-italia K2 / FAMILY CLUB
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
 rtp://239.186.74.21:10000
-#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="http://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Discovery-italia NOVE
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE" tvg-logo="http://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Discovery-italia NOVE
 rtp://239.186.64.158:10000
-#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="http://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Discovery-italia Real Time
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time" tvg-logo="http://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Discovery-italia Real Time
 rtp://239.186.66.43:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="http://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="http://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
 #EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="http://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",food network I
 rtp://239.186.66.122:10000
-#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="Italia Channel" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
 rtp://239.186.64.49:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
 rtp://239.186.70.7:10000
-#EXTINF:-1 tvg-id="LA7d.it@SD" tvg-name="La7D IT" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
+#EXTINF:-1 tvg-id="LA7d.it@SD" tvg-name="La 7d" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
 rtp://239.186.64.164:10000
-#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo TV DE" tvg-logo="http://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="369" channel-id="369",MARCOPOLO.TV
+#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo" tvg-logo="http://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="369" channel-id="369",MARCOPOLO.TV
 rtp://239.186.74.20:10000
-#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="http://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",MEDIASET 20 HD
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset" tvg-logo="http://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",MEDIASET 20 HD
 rtp://239.186.70.152:10000
-#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
 rtp://239.186.64.46:10000
-#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
 rtp://239.186.68.163:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="http://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra" tvg-logo="http://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
 rtp://239.186.66.37:10000
-#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="http://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus" tvg-logo="http://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
 rtp://239.186.66.69:10000
-#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
 rtp://239.186.64.48:10000
-#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
 rtp://239.186.68.165:10000
-#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="http://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2" tvg-logo="http://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
 rtp://239.186.66.44:10000
-#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="http://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="IRIS" tvg-logo="http://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
 rtp://239.186.64.75:10000
-#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="http://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5" tvg-logo="http://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
 rtp://239.186.64.73:10000
-#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="" tvg-logo="" tvg-chno="380" channel-id="380",MEDIASET Rete4
+#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="Rete 4" tvg-logo="" tvg-chno="380" channel-id="380",MEDIASET Rete4
 rtp://239.186.64.47:10000
-#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="" tvg-logo="" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="TGCom24" tvg-logo="" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
 rtp://239.186.64.214:10000
-#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="http://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime" tvg-logo="http://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
 rtp://239.186.66.180:10000
-#EXTINF:-1 tvg-id="ParamountChannel.it" tvg-name="Paramount Channel IT" tvg-logo="http://static.epg.best/it/ParamountChannel.it.png" tvg-chno="383" channel-id="383",Paramount Channel I
+#EXTINF:-1 tvg-id="ParamountChannel.fr@SD" tvg-name="Paramount F" tvg-logo="http://static.epg.best/it/ParamountChannel.it.png" tvg-chno="383" channel-id="383",Paramount Channel I
 rtp://239.186.64.122:10000
-#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai 1" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
 rtp://239.186.64.43:10000
-#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai 1" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
 rtp://239.186.68.36:10000
-#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai 2" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
 rtp://239.186.64.44:10000
-#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai 2" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
 rtp://239.186.70.77:10000
-#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai 3" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
 rtp://239.186.64.45:10000
-#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai 3" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
 rtp://239.186.70.78:10000
-#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="http://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4" tvg-logo="http://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
 rtp://239.186.64.50:10000
-#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="http://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5" tvg-logo="http://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="http://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp" tvg-logo="http://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
 rtp://233.35.254.98:1234
-#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="http://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie" tvg-logo="http://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
 rtp://239.186.66.185:10000
-#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="http://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24" tvg-logo="http://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
 rtp://239.186.64.156:10000
-#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="http://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium" tvg-logo="http://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
 rtp://239.186.66.183:10000
-#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="http://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola" tvg-logo="http://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
 rtp://239.186.66.34:10000
-#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport+
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="Rai Sport +" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport+
 rtp://239.186.64.157:10000
-#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport+ HD
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="Rai Sport +" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport+ HD
 rtp://239.186.70.2:10000
-#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="" tvg-logo="" tvg-chno="399" channel-id="399",Rai Sport
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="Rai Sport +" tvg-logo="" tvg-chno="399" channel-id="399",Rai Sport
 rtp://239.186.64.159:10000
-#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="http://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia" tvg-logo="http://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
 rtp://239.186.64.162:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="http://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo" tvg-logo="http://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
 rtp://239.186.68.5:10000
-#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
-#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 HD
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 HD
 rtp://239.186.68.6:10000
-#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="http://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="sky TG 24" tvg-logo="http://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
 rtp://239.186.66.177:10000
-#EXTINF:-1 tvg-id="1347" tvg-name="SpikeTV IT" tvg-logo="http://static.epg.best/it/SpikeTV.it.png" tvg-chno="407" channel-id="407",Spike
+#EXTINF:-1 tvg-id="" tvg-name="SpikeTV IT" tvg-logo="http://static.epg.best/it/SpikeTV.it.png" tvg-chno="407" channel-id="407",Spike
 rtp://239.186.66.178:10000
-#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="http://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport Italia SI
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="SPORTITALIA" tvg-logo="http://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport Italia SI
 rtp://239.186.74.24:10000
-#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="super! IT" tvg-logo="" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super!" tvg-logo="" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis IT" tvg-logo="http://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SUPER TENNIS HD
+#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis TV" tvg-logo="http://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SUPER TENNIS HD
 rtp://239.186.70.154:10000
-#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="" tvg-logo="" tvg-chno="410" channel-id="410",teleticino
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="Tele Ticino" tvg-logo="" tvg-chno="410" channel-id="410",teleticino
 rtp://239.186.64.99:10000
-#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="" tvg-logo="" tvg-chno="411" channel-id="411",teleticino HD
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="Tele Ticino" tvg-logo="" tvg-chno="411" channel-id="411",teleticino HD
 rtp://239.186.68.201:10000
-#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="Telelombardia" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
 rtp://239.186.64.154:10000
-#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="Telenova" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
 rtp://239.186.64.152:10000
-#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="http://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8" tvg-logo="http://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
 rtp://239.186.64.161:10000
-#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="UniNettuno University TV" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="645" tvg-name="VH1 IT" tvg-logo="http://static.epg.best/it/VH1.it.png" tvg-chno="418" channel-id="418",VH1 Italia
+#EXTINF:-1 tvg-id="" tvg-name="VH1" tvg-logo="http://static.epg.best/it/VH1.it.png" tvg-chno="418" channel-id="418",VH1 Italia
 rtp://239.186.66.240:10000
-#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="" tvg-logo="" tvg-chno="415" channel-id="415",TV2000
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000" tvg-logo="" tvg-chno="415" channel-id="415",TV2000
 rtp://239.186.66.108:10000
 #EXTREM:others
-#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="http://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde" tvg-logo="http://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="360.tr@SD" tvg-name="" tvg-logo="" tvg-chno="420" channel-id="420",360
+#EXTINF:-1 tvg-id="360.tr@SD" tvg-name="360" tvg-logo="" tvg-chno="420" channel-id="420",360
 rtp://239.186.64.204:10000
-#EXTINF:-1 tvg-id="ATVAvrupa.tr@SD" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv avrupa
+#EXTINF:-1 tvg-id="ATVAvrupa.tr@SD" tvg-name="ATV Avrupa" tvg-logo="" tvg-chno="421" channel-id="421",atv avrupa
 rtp://239.186.64.201:10000
-#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="http://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="TV Ora" tvg-logo="http://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
 rtp://239.186.64.196:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="423" channel-id="423",Canal Extremadura
 rtp://239.186.64.222:10000
-#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D NL" tvg-logo="http://static.epg.best/nl/EuroD.nl.png" tvg-chno="424" channel-id="424",EURO D
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D" tvg-logo="http://static.epg.best/nl/EuroD.nl.png" tvg-chno="424" channel-id="424",EURO D
 rtp://239.186.64.199:10000
-#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar NL" tvg-logo="http://static.epg.best/nl/Eurostar.nl.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Euro Star" tvg-logo="http://static.epg.best/nl/Eurostar.nl.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="320" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
+#EXTINF:-1 tvg-id="" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
 rtp://239.186.66.134:10000
-#EXTINF:-1 tvg-id="320" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
+#EXTINF:-1 tvg-id="" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
-#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
 rtp://239.186.64.200:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
 rtp://239.186.84.36:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="http://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="http://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
 #EXTINF:-1 tvg-id="TVNET.tr" tvg-name="TVNET TR" tvg-logo="http://static.epg.best/tr/TVNET.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
 rtp://239.186.64.205:10000
-#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="http://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya" tvg-logo="http://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
 rtp://239.186.64.192:10000
-#EXTINF:-1 tvg-id="AB1.fr@SD" tvg-name="B1 RO" tvg-logo="http://static.epg.best/ro/B1.ro.png" tvg-chno="433" channel-id="433",b1
+#EXTINF:-1 tvg-id="AB1.fr@SD" tvg-name="AB1" tvg-logo="http://static.epg.best/ro/B1.ro.png" tvg-chno="433" channel-id="433",b1
 rtp://239.186.66.111:10000
-#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="http://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN TV" tvg-logo="http://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV4" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
 rtp://239.186.64.195:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV4" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
 rtp://239.186.70.89:10000
-#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 1 IL" tvg-logo="http://static.epg.best/il/Channel1.il.png" tvg-chno="437" channel-id="437",Channel1 RU
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5" tvg-logo="http://static.epg.best/il/Channel1.il.png" tvg-chno="437" channel-id="437",Channel1 RU
 rtp://239.186.64.82:10000
-#EXTINF:-1 tvg-id="409" tvg-name="" tvg-logo="" tvg-chno="438" channel-id="438",CTC International
+#EXTINF:-1 tvg-id="" tvg-name="CTC International" tvg-logo="" tvg-chno="438" channel-id="438",CTC International
 rtp://239.186.66.117:10000
-#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="DM Sat TV" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="http://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV" tvg-logo="http://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI
 rtp://239.186.66.119:10000
-#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="http://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV" tvg-logo="http://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
 rtp://239.186.66.120:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="http://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World" tvg-logo="http://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
 rtp://239.186.66.85:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="443" channel-id="443",ESC1 (Al Masriya)
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World CA" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
-#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="" tvg-logo="" tvg-chno="446" channel-id="446",HRT1
+#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT 1" tvg-logo="" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="http://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN TV
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="Kurdistan TV" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN TV
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="449" channel-id="449",KURDISTAN TV HD
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="Kurdistan TV" tvg-logo="" tvg-chno="449" channel-id="449",KURDISTAN TV HD
 rtp://239.186.70.129:10000
-#EXTINF:-1 tvg-id="1401" tvg-name="Kuriakos Tv PT" tvg-logo="http://static.epg.best/pt/KuriakosTv.pt.png" tvg-chno="450" channel-id="450",KURIAKOS TV HD
+#EXTINF:-1 tvg-id="" tvg-name="Kuriakos TV" tvg-logo="http://static.epg.best/pt/KuriakosTv.pt.png" tvg-chno="450" channel-id="450",KURIAKOS TV HD
 rtp://239.186.70.149:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
 rtp://239.186.66.132:10000
 #EXTINF:-1 tvg-id="PlanetTurk.tr" tvg-name="Planet Türk TR" tvg-logo="http://static.epg.best/tr/PlanetTurk.tr.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="453" channel-id="453",PTC CBET HD
 rtp://239.186.70.164:10000
-#EXTINF:-1 tvg-id="324" tvg-name="" tvg-logo="" tvg-chno="454" channel-id="454",PTPC www.rtrs.tv
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="454" channel-id="454",PTPC www.rtrs.tv
 rtp://239.186.66.136:10000
-#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="http://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="http://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="http://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",RUDAW HD
+#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="Rudaw TV" tvg-logo="" tvg-chno="460" channel-id="460",RUDAW HD
 rtp://239.186.68.247:10000
-#EXTINF:-1 tvg-id="602" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="" tvg-name="TGRT EU" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="http://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdi" tvg-logo="http://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
 rtp://239.186.66.204:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="http://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="http://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
-#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="" tvg-logo="" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="TV Romania International" tvg-logo="" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
-#EXTINF:-1 tvg-id="Z1.hr@SD" tvg-name="" tvg-logo="" tvg-chno="466" channel-id="466",Z1
+#EXTINF:-1 tvg-id="Z1.hr@SD" tvg-name="Z1 Televizija" tvg-logo="" tvg-chno="466" channel-id="466",Z1
 rtp://239.186.66.149:10000
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia TV
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="Canal Sur Andalucía" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia TV
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="http://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="Televisión de Galicia" tvg-logo="http://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
 rtp://239.186.64.187:10000
-#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="" tvg-logo="" tvg-chno="469" channel-id="469",tve international
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="TVE Internacional" tvg-logo="" tvg-chno="469" channel-id="469",tve international
 rtp://239.186.64.54:10000
-#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record Int. EU
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record Int. EU
 rtp://239.186.64.83:10000
-#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record Int. EU HD
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record Int. EU HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
 rtp://239.186.64.77:10000

--- a/swisscom-full.m3u
+++ b/swisscom-full.m3u
@@ -922,7 +922,7 @@ rtp://239.186.66.204:10000
 rtp://239.186.66.147:10000
 #EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="" tvg-logo="" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="466" channel-id="466",Z1
+#EXTINF:-1 tvg-id="Z1.hr@SD" tvg-name="" tvg-logo="" tvg-chno="466" channel-id="466",Z1
 rtp://239.186.66.149:10000
 #EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia TV
 rtp://239.186.64.197:10000

--- a/swisscom-full.m3u
+++ b/swisscom-full.m3u
@@ -82,15 +82,15 @@ rtp://233.21.50.5:1234
 rtp://233.21.50.11:1234
 #EXTINF:-1 tvg-id="DisneyJr.fr@SD" tvg-name="Disney Junior F" tvg-logo="http://static.epg.best/fr/DisneyJunior.fr.png" tvg-chno="8" channel-id="8",Disney Junior HD french (fra/eng)
 rtp://233.21.50.31:1234
-#EXTINF:-1 tvg-id="" tvg-name="Disney XD F" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
+#EXTINF:-1 tvg-id="DisneyXD" tvg-name="Disney XD F" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
 rtp://233.21.50.52:1234
-#EXTINF:-1 tvg-id="" tvg-name="Disney Cinema F" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
+#EXTINF:-1 tvg-id="DisnCineHD" tvg-name="Disney Cinema F" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
 rtp://233.21.50.70:1234
 #EXTINF:-1 tvg-id="Mangas.fr@SD" tvg-name="Mangas" tvg-logo="http://static.epg.best/fr/Mangas.fr.png" tvg-chno="11" channel-id="11",Mangas
 rtp://233.21.50.2:1234
-#EXTINF:-1 tvg-id="" tvg-name="Motorsport TV" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
+#EXTINF:-1 tvg-id="Motorsporttv.fr@SD" tvg-name="Motorvision.TV France" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
 rtp://233.21.50.27:1234
-#EXTINF:-1 tvg-id="" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
+#EXTINF:-1 tvg-id="NationalGeographicChannelFrance" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
 rtp://233.21.50.54:1234
 #EXTINF:-1 tvg-id="NatGeoWildFrance" tvg-name="Nat Geo Wild FR" tvg-logo="http://static.epg.best/fr/NatGeoWild.fr.png" tvg-chno="14" channel-id="14",Nat Geo Wild HD French (fra/eng)
 rtp://233.21.50.55:1234
@@ -100,13 +100,13 @@ rtp://233.21.50.57:1234
 rtp://233.21.50.58:1234
 #EXTINF:-1 tvg-id="ParamountChannel.fr@SD" tvg-name="Paramount F" tvg-logo="http://static.epg.best/fr/ParamountChannel.fr.png" tvg-chno="18" channel-id="18",Paramount Channel HD French
 rtp://233.21.50.126:1234
-#EXTINF:-1 tvg-id="" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
+#EXTINF:-1 tvg-id="EquidiaLive.fr" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
 rtp://233.32.39.142:1234
 #EXTINF:-1 tvg-id="ChassePeche.fr@SD" tvg-name="Chasse et Peche" tvg-logo="http://static.epg.best/fr/ChassePeche.fr.png" tvg-chno="21" channel-id="21",Chasse et Peche
 rtp://233.32.39.143:1234
 #EXTINF:-1 tvg-id="GolfChannel.fr@SD" tvg-name="Golf Channel" tvg-logo="http://static.epg.best/us/GolfChannel.us.png" tvg-chno="22" channel-id="22",Golf Channel
 rtp://233.32.39.154:1234
-#EXTINF:-1 tvg-id="" tvg-name="RMC Sport Access 3" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
+#EXTINF:-1 tvg-id="RMCSportAccess2" tvg-name="RMC Sport Access 2" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
 rtp://233.32.39.164:1234
 #EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
 rtp://239.186.64.144:10000
@@ -245,9 +245,9 @@ rtp://239.186.68.41:10000
 rtp://239.186.64.166:10000
 #EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="123" channel-id="123",BBC CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
+#EXTINF:-1 tvg-id="BBCFour.uk@UK" tvg-name="BBC Four" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
 rtp://239.186.64.52:10000
-#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="BBCFour.uk@UK" tvg-name="BBC Four" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
 #EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
@@ -291,7 +291,7 @@ rtp://239.186.64.175:10000
 rtp://239.186.70.23:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="207" channel-id="207",DW Deutsche Welle English
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="" tvg-name="Drama" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
+#EXTINF:-1 tvg-id="Drama.uk" tvg-name="Drama" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
 rtp://239.186.66.140:10000
 #EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4" tvg-logo="http://static.epg.best/uk/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
@@ -460,9 +460,9 @@ rtp://239.186.64.133:10000
 rtp://239.186.66.231:10000
 #EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="222" channel-id="222",LOLY HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
-#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
 #EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="" tvg-chno="231" channel-id="231",Melodie TV
 rtp://239.186.74.15:10000
@@ -474,9 +474,9 @@ rtp://239.186.68.174:10000
 rtp://239.186.68.207:10000
 #EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="http://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
-#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="238" channel-id="238",nick schweiz
 rtp://239.186.64.186:10000
@@ -522,9 +522,9 @@ rtp://239.186.70.40:10000
 rtp://239.186.64.15:10000
 #EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH HD
 rtp://233.35.254.237:1234
-#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
+#EXTINF:-1 tvg-id="RTLZwei.de@SD" tvg-name="RTL ZWEI" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
+#EXTINF:-1 tvg-id="RTLPlus.de" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
 rtp://239.186.66.201:10000
 #EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1" tvg-logo="http://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
@@ -662,9 +662,9 @@ rtp://239.186.70.65:10000
 rtp://239.186.64.61:10000
 #EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="http://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
-#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
 #EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
@@ -701,7 +701,7 @@ rtp://239.186.64.160:10000
 rtp://239.186.66.176:10000
 #EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo" tvg-logo="http://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
 rtp://239.186.64.76:10000
-#EXTINF:-1 tvg-id="" tvg-name="CineSony IT" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
+#EXTINF:-1 tvg-id="CineSony.it" tvg-name="Cine Sony" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
 rtp://239.186.74.22:10000
 #EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="Class TV Moda" tvg-logo="" tvg-chno="354" channel-id="354",Class TV Moda
 rtp://239.186.66.189:10000
@@ -846,9 +846,9 @@ rtp://239.186.64.222:10000
 rtp://239.186.64.199:10000
 #EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Euro Star" tvg-logo="http://static.epg.best/nl/Eurostar.nl.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
+#EXTINF:-1 tvg-id="Powerturk.tr" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
 rtp://239.186.66.134:10000
-#EXTINF:-1 tvg-id="" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
+#EXTINF:-1 tvg-id="Powerturk.tr" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
 rtp://239.186.70.122:10000
 #EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
@@ -934,5 +934,5 @@ rtp://239.186.64.54:10000
 rtp://239.186.64.83:10000
 #EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record Int. EU HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="RTPMundo.pt@SD" tvg-name="RTP Mundo" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Mundo
 rtp://239.186.64.77:10000

--- a/swisscom-full.m3u
+++ b/swisscom-full.m3u
@@ -1,72 +1,72 @@
 #EXTM3U url-tvg="#EXTM3U url-tvg="https://xmltv.ch/xmltv/xmltv-complet.xml""
 #EXTREM:french
-#EXTINF:-1 tvg-id="C202.api.telerama.fr" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS Un
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS Un
 rtp://239.186.64.5:10000
-#EXTINF:-1 tvg-id="C202.api.telerama.fr" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="92" channel-id="92",RTS Un HD
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="http://static.epg.best/ch/RTS1.ch.png" tvg-chno="92" channel-id="92",RTS Un HD
 rtp://239.186.68.3:10000
-#EXTINF:-1 tvg-id="C183.api.telerama.fr" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS Deux
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS Deux
 rtp://239.186.64.6:10000
-#EXTINF:-1 tvg-id="C183.api.telerama.fr" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="94" channel-id="94",RTS Deux HD
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="http://static.epg.best/ch/RTS2.ch.png" tvg-chno="94" channel-id="94",RTS Deux HD
 rtp://239.186.68.4:10000
-#EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
+#EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
 rtp://239.186.64.35:10000
-#EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="100" channel-id="100",TF1 CH HD
+#EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="http://static.epg.best/fr/TF1.fr.png" tvg-chno="100" channel-id="100",TF1 CH HD
 rtp://233.35.254.133:1234
-#EXTINF:-1 tvg-id="France2.fr" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
 rtp://239.186.64.36:10000
-#EXTINF:-1 tvg-id="France2.fr" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="55" channel-id="55",France2 HD
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="http://static.epg.best/fr/France2.fr.png" tvg-chno="55" channel-id="55",France2 HD
 rtp://239.186.68.19:10000
-#EXTINF:-1 tvg-id="France3.fr" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
 rtp://239.186.64.37:10000
-#EXTINF:-1 tvg-id="France3.fr" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="57" channel-id="57",France3 HD
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="http://static.epg.best/fr/France3.fr.png" tvg-chno="57" channel-id="57",France3 HD
 rtp://239.186.70.25:10000
-#EXTINF:-1 tvg-id="France4.fr" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="" channel-id="",France4
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="" channel-id="",France4
 rtp://239.186.64.38:10000
-#EXTINF:-1 tvg-id="France4.fr" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 HD
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="http://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 HD
 rtp://239.186.84.55:10000
-#EXTINF:-1 tvg-id="France5" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
 rtp://239.186.64.39:10000
-#EXTINF:-1 tvg-id="France5" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="60" channel-id="60",France5 HD
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="http://static.epg.best/fr/France5.fr.png" tvg-chno="60" channel-id="60",France5 HD
 rtp://239.186.70.27:10000
-#EXTINF:-1 tvg-id="M6.fr" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
 rtp://239.186.64.40:10000
-#EXTINF:-1 tvg-id="M6.fr" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="80" channel-id="80",M6 CH HD
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="http://static.epg.best/fr/M6.fr.png" tvg-chno="80" channel-id="80",M6 CH HD
 rtp://233.35.254.130:1234
-#EXTINF:-1 tvg-id="6ter.fr" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH
 rtp://239.186.66.130:10000
-#EXTINF:-1 tvg-id="6ter.fr" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH HD
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="http://static.epg.best/fr/6ter.fr.png" tvg-chno="" channel-id="",6ter CH HD
 rtp://239.186.68.134:10000
-#EXTINF:-1 tvg-id="TMC.fr" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
 rtp://239.186.64.127:10000
-#EXTINF:-1 tvg-id="TMC.fr" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="104" channel-id="104",TMC CH HD
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="http://static.epg.best/fr/TMC.fr.png" tvg-chno="104" channel-id="104",TMC CH HD
 rtp://239.186.70.37:10000
-#EXTINF:-1 tvg-id="NRJ12.fr" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="83" channel-id="83",NRJ12 CH
+#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="83" channel-id="83",NRJ12 CH
 rtp://239.186.64.58:10000
-#EXTINF:-1 tvg-id="NRJ12.fr" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="84" channel-id="84",NRJ12 CH HD
+#EXTINF:-1 tvg-id="NRJ12.fr@SD" tvg-name="NRJ 12 FR" tvg-logo="http://static.epg.best/fr/NRJ12.fr.png" tvg-chno="84" channel-id="84",NRJ12 CH HD
 rtp://239.186.70.33:10000
-#EXTINF:-1 tvg-id="NT1.fr" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH (ex NT1)
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH (ex NT1)
 rtp://239.186.64.42:10000
-#EXTINF:-1 tvg-id="NT1.fr" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="102" channel-id="102",TFX CH HD (ex NT1 HD)
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="http://static.epg.best/fr/TFX.fr.png" tvg-chno="102" channel-id="102",TFX CH HD (ex NT1 HD)
 rtp://239.186.70.34:10000
-#EXTINF:-1 tvg-id="C8.fr" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="48" channel-id="48",C8 CH
 rtp://239.186.64.59:10000
-#EXTINF:-1 tvg-id="C8.fr" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
+#EXTINF:-1 tvg-id="C8.fr@SD" tvg-name="C8 FR" tvg-logo="http://static.epg.best/fr/C8.fr.png" tvg-chno="49" channel-id="49",C8 CH HD
 rtp://239.186.68.215:10000
-#EXTINF:-1 tvg-id="W9.fr" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
 rtp://239.186.66.24:10000
-#EXTINF:-1 tvg-id="W9.fr" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="114" channel-id="114",W9 CH HD
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="http://static.epg.best/fr/W9.fr.png" tvg-chno="114" channel-id="114",W9 CH HD
 rtp://239.186.70.38:10000
-#EXTINF:-1 tvg-id="RTL9.fr" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH HD
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH HD
 rtp://239.186.68.242:10000
-#EXTINF:-1 tvg-id="Arte.fr" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
 rtp://239.186.64.57:10000
-#EXTINF:-1 tvg-id="Arte.fr" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="33" channel-id="33",arte F HD
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="http://static.epg.best/fr/ARTE.fr.png" tvg-chno="33" channel-id="33",arte F HD
 rtp://239.186.68.18:10000
-#EXTINF:-1 tvg-id="AB3" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="AB3" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="31" channel-id="31",AB3 CH HD
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="31" channel-id="31",AB3 CH HD
 rtp://239.186.68.33:10000
-#EXTINF:-1 tvg-id="OCSMax" tvg-name="OCS Max FR" tvg-logo="http://static.epg.best/fr/OCSMax.fr.png" tvg-chno="1" channel-id="1",OCS Max FR
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="OCS Max FR" tvg-logo="http://static.epg.best/fr/OCSMax.fr.png" tvg-chno="1" channel-id="1",OCS Max FR
 rtp://233.21.50.59:1234
 #EXTINF:-1 tvg-id="OCSCity" tvg-name="OCS City FR" tvg-logo="http://static.epg.best/fr/OCSCity.fr.png" tvg-chno="2" channel-id="2",OCS City FR
 rtp://233.21.50.60:1234
@@ -74,865 +74,865 @@ rtp://233.21.50.60:1234
 rtp://233.21.50.61:1234
 #EXTINF:-1 tvg-id="OcsGeants" tvg-name="Ocs Geants FR" tvg-logo="http://static.epg.best/mu/OcsGeants.mu.png" tvg-chno="4" channel-id="4",OCS Geants FR
 rtp://233.21.50.62:1234
-#EXTINF:-1 tvg-id="13eRue" tvg-name="13e Rue FR" tvg-logo="http://static.epg.best/fr/13Rue.fr.png" tvg-chno="5" channel-id="5",13ème Rue HD FR
+#EXTINF:-1 tvg-id="13emeRue.fr@SD" tvg-name="13e Rue FR" tvg-logo="http://static.epg.best/fr/13Rue.fr.png" tvg-chno="5" channel-id="5",13ème Rue HD FR
 rtp://233.21.50.4:1234
-#EXTINF:-1 tvg-id="SyfyF" tvg-name="Syfy FR" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
+#EXTINF:-1 tvg-id="SYFY.de@SD" tvg-name="Syfy FR" tvg-logo="http://static.epg.best/fr/Syfy.fr.png" tvg-chno="6" channel-id="6",SyFy HD French
 rtp://233.21.50.5:1234
-#EXTINF:-1 tvg-id="DisneyChannel" tvg-name="Disney Channel FR" tvg-logo="http://static.epg.best/fr/DisneyChannel.fr.png" tvg-chno="7" channel-id="7",Disney Channel HD french (fra/eng)
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel FR" tvg-logo="http://static.epg.best/fr/DisneyChannel.fr.png" tvg-chno="7" channel-id="7",Disney Channel HD french (fra/eng)
 rtp://233.21.50.11:1234
-#EXTINF:-1 tvg-id="DisneyJunior" tvg-name="Disney Junior FR" tvg-logo="http://static.epg.best/fr/DisneyJunior.fr.png" tvg-chno="8" channel-id="8",Disney Junior HD french (fra/eng)
+#EXTINF:-1 tvg-id="131" tvg-name="Disney Junior FR" tvg-logo="http://static.epg.best/fr/DisneyJunior.fr.png" tvg-chno="8" channel-id="8",Disney Junior HD french (fra/eng)
 rtp://233.21.50.31:1234
-#EXTINF:-1 tvg-id="DisneyXD" tvg-name="Disney XD FR" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
+#EXTINF:-1 tvg-id="133" tvg-name="Disney XD FR" tvg-logo="http://static.epg.best/fr/DisneyXD.fr.png" tvg-chno="9" channel-id="9",Disney XD HD french
 rtp://233.21.50.52:1234
-#EXTINF:-1 tvg-id="DisnCineHD" tvg-name="Disney Cinema FR" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
+#EXTINF:-1 tvg-id="1068" tvg-name="Disney Cinema FR" tvg-logo="http://static.epg.best/fr/DisneyCinema.fr.png" tvg-chno="10" channel-id="10",Disney Cinema HD french (fra/eng)
 rtp://233.21.50.70:1234
-#EXTINF:-1 tvg-id="Mangas" tvg-name="Mangas FR" tvg-logo="http://static.epg.best/fr/Mangas.fr.png" tvg-chno="11" channel-id="11",Mangas
+#EXTINF:-1 tvg-id="Mangas.fr@SD" tvg-name="Mangas FR" tvg-logo="http://static.epg.best/fr/Mangas.fr.png" tvg-chno="11" channel-id="11",Mangas
 rtp://233.21.50.2:1234
-#EXTINF:-1 tvg-id="motorsporttv" tvg-name="Motorsport TV FR" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
+#EXTINF:-1 tvg-id="263" tvg-name="Motorsport TV FR" tvg-logo="http://static.epg.best/fr/MotorsportTV.fr.png" tvg-chno="12" channel-id="12",motorsport.tv HD (fra/eng)
 rtp://233.21.50.27:1234
-#EXTINF:-1 tvg-id="NationalGeographicChannelFrance" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
+#EXTINF:-1 tvg-id="281" tvg-name="Nat Geo FR" tvg-logo="http://static.epg.best/fr/NatGeo.fr.png" tvg-chno="13" channel-id="13",National Geographic HD French
 rtp://233.21.50.54:1234
 #EXTINF:-1 tvg-id="NatGeoWildFrance" tvg-name="Nat Geo Wild FR" tvg-logo="http://static.epg.best/fr/NatGeoWild.fr.png" tvg-chno="14" channel-id="14",Nat Geo Wild HD French (fra/eng)
 rtp://233.21.50.55:1234
-#EXTINF:-1 tvg-id="TvBreizh" tvg-name="Tv Breizh FR" tvg-logo="http://static.epg.best/fr/TvBreizh.fr.png" tvg-chno="16" channel-id="16",TV Breizh HD
+#EXTINF:-1 tvg-id="TVBreizh.fr@SD" tvg-name="Tv Breizh FR" tvg-logo="http://static.epg.best/fr/TvBreizh.fr.png" tvg-chno="16" channel-id="16",TV Breizh HD
 rtp://233.21.50.57:1234
-#EXTINF:-1 tvg-id="UshuaiaTV" tvg-name="Ushuaïa TV FR" tvg-logo="http://static.epg.best/fr/UshuaiaTV.fr.png" tvg-chno="17" channel-id="17",Ushuaia TV HD
+#EXTINF:-1 tvg-id="UshuaiaTV.fr@SD" tvg-name="Ushuaïa TV FR" tvg-logo="http://static.epg.best/fr/UshuaiaTV.fr.png" tvg-chno="17" channel-id="17",Ushuaia TV HD
 rtp://233.21.50.58:1234
 #EXTINF:-1 tvg-id="ParamountChannel.fr" tvg-name="Paramount Channel FR" tvg-logo="http://static.epg.best/fr/ParamountChannel.fr.png" tvg-chno="18" channel-id="18",Paramount Channel HD French
 rtp://233.21.50.126:1234
-#EXTINF:-1 tvg-id="EquidiaLive.fr" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
+#EXTINF:-1 tvg-id="150" tvg-name="Equidia FR" tvg-logo="http://static.epg.best/fr/Equidia.fr.png" tvg-chno="20" channel-id="20",Equidia
 rtp://233.32.39.142:1234
-#EXTINF:-1 tvg-id="ChassePeche.fr" tvg-name="Chasse et pêche FR" tvg-logo="http://static.epg.best/fr/ChassePeche.fr.png" tvg-chno="21" channel-id="21",Chasse et Peche
+#EXTINF:-1 tvg-id="ChassePeche.fr@SD" tvg-name="Chasse et pêche FR" tvg-logo="http://static.epg.best/fr/ChassePeche.fr.png" tvg-chno="21" channel-id="21",Chasse et Peche
 rtp://233.32.39.143:1234
-#EXTINF:-1 tvg-id="GolfChannel" tvg-name="Golf Channel US" tvg-logo="http://static.epg.best/us/GolfChannel.us.png" tvg-chno="22" channel-id="22",Golf Channel
+#EXTINF:-1 tvg-id="GolfChannel.fr@SD" tvg-name="Golf Channel US" tvg-logo="http://static.epg.best/us/GolfChannel.us.png" tvg-chno="22" channel-id="22",Golf Channel
 rtp://233.32.39.154:1234
-#EXTINF:-1 tvg-id="RMCSportAccess2" tvg-name="" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
+#EXTINF:-1 tvg-id="1039" tvg-name="" tvg-logo="" tvg-chno="24" channel-id="24",RMC SPORT Access 2 HD
 rtp://233.32.39.164:1234
-#EXTINF:-1 tvg-id="8MontBlanc" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
 rtp://239.186.64.144:10000
-#EXTINF:-1 tvg-id="8MontBlanc" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="29" channel-id="29",8Mont-Blanc HD
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="http://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="29" channel-id="29",8Mont-Blanc HD
 rtp://239.186.70.106:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
+#EXTINF:-1 tvg-id="TeleSwizz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="34" channel-id="34",TeleSwiss HD
 rtp://239.186.68.208:10000
-#EXTINF:-1 tvg-id="BFMBusiness.fr" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="35" channel-id="35",BFM BUSINESS
+#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="35" channel-id="35",BFM BUSINESS
 rtp://239.186.64.146:10000
-#EXTINF:-1 tvg-id="BFMBusiness.fr" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="36" channel-id="36",BFM BUSINESS HD
+#EXTINF:-1 tvg-id="BFMBusiness.fr@SD" tvg-name="BFM Business FR" tvg-logo="http://static.epg.best/fr/BFMBusiness.fr.png" tvg-chno="36" channel-id="36",BFM BUSINESS HD
 rtp://239.186.70.74:10000
-#EXTINF:-1 tvg-id="BFMTV.fr" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
 rtp://239.186.64.72:10000
-#EXTINF:-1 tvg-id="BFMTV.fr" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="38" channel-id="38",BFMTV CH HD
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="http://static.epg.best/fr/BFMTV.fr.png" tvg-chno="38" channel-id="38",BFMTV CH HD
 rtp://239.186.68.196:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="39" channel-id="39",TV Suisse plus
+#EXTINF:-1 tvg-id="113" tvg-name="" tvg-logo="" tvg-chno="39" channel-id="39",TV Suisse plus
 rtp://239.186.66.239:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="40" channel-id="40",TV Suisse plus HD
+#EXTINF:-1 tvg-id="113" tvg-name="" tvg-logo="" tvg-chno="40" channel-id="40",TV Suisse plus HD
 rtp://239.186.70.104:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="42" channel-id="42",Canal9
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="" tvg-logo="" tvg-chno="42" channel-id="42",Canal9
 rtp://239.186.64.108:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="43" channel-id="43",Canal9 HD
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="" tvg-logo="" tvg-chno="43" channel-id="43",Canal9 HD
 rtp://239.186.68.144:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
 rtp://239.186.64.106:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="45" channel-id="45",CanalAlpha JU HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="45" channel-id="45",CanalAlpha JU HD
 rtp://239.186.68.193:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
 rtp://239.186.64.92:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="47" channel-id="47",Canal Alpha NE HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="http://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="47" channel-id="47",Canal Alpha NE HD
 rtp://239.186.68.194:10000
-#EXTINF:-1 tvg-id="CStar.fr" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="50" channel-id="50",CSTAR
+#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="50" channel-id="50",CSTAR
 rtp://239.186.66.26:10000
-#EXTINF:-1 tvg-id="CStar.fr" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="51" channel-id="51",CSTAR HD
+#EXTINF:-1 tvg-id="CStar.fr@SD" tvg-name="CStar FR" tvg-logo="http://static.epg.best/fr/CStar.fr.png" tvg-chno="51" channel-id="51",CSTAR HD
 rtp://239.186.70.24:10000
-#EXTINF:-1 tvg-id="EuronewsF" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
 rtp://239.186.64.151:10000
-#EXTINF:-1 tvg-id="EuronewsF" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="53" channel-id="53",euronews. F HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="http://static.epg.best/fr/Euronews.fr.png" tvg-chno="53" channel-id="53",euronews. F HD
 rtp://239.186.70.148:10000
-#EXTINF:-1 tvg-id="L'Equipe21FR" tvg-name="LEquipe21 FR" tvg-logo="http://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="474" channel-id="474",EQUIPE HD
+#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="LEquipe21 FR" tvg-logo="http://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="474" channel-id="474",EQUIPE HD
 rtp://239.186.79.78:10000
-#EXTINF:-1 tvg-id="FranceInfo" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
 rtp://239.186.66.225:10000
-#EXTINF:-1 tvg-id="FranceInfo" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="" channel-id="",franceinfo HD
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="http://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="" channel-id="",franceinfo HD
 rtp://239.186.70.121:10000
-#EXTINF:-1 tvg-id="France24F" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
 rtp://239.186.64.41:10000
-#EXTINF:-1 tvg-id="France24F" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24 HD
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="http://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24 HD
 rtp://239.186.70.125:10000
-#EXTINF:-1 tvg-id="Gulli.fr" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
 rtp://239.186.66.23:10000
-#EXTINF:-1 tvg-id="Gulli.fr" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="65" channel-id="65",gulli HD
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="http://static.epg.best/fr/Gulli.fr.png" tvg-chno="65" channel-id="65",gulli HD
 rtp://239.186.70.29:10000
-#EXTINF:-1 tvg-id="i24News" tvg-name="I24 News FR" tvg-logo="" tvg-chno="66" channel-id="66",i24 NEWS F
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24 News FR" tvg-logo="" tvg-chno="66" channel-id="66",i24 NEWS F
 rtp://239.186.66.174:10000
-#EXTINF:-1 tvg-id="i24News" tvg-name="I24 News FR" tvg-logo="" tvg-chno="67" channel-id="67",i24 NEWS F HD
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24 News FR" tvg-logo="" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
-#EXTINF:-1 tvg-id="CNews.fr" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
 rtp://239.186.66.25:10000
-#EXTINF:-1 tvg-id="CNews.fr" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="69" channel-id="69",CNEWS HD
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="http://static.epg.best/fr/CNews.fr.png" tvg-chno="69" channel-id="69",CNEWS HD
 rtp://239.186.70.30:10000
-#EXTINF:-1 tvg-id="KTO" tvg-name="KTO FR" tvg-logo="http://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="http://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="" tvg-logo="" tvg-chno="71" channel-id="71",Grand Geneve TV HD
 rtp://239.186.70.133:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="72" channel-id="72",LA TELE
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="72" channel-id="72",LA TELE
 rtp://239.186.64.104:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE FR HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="" tvg-logo="" tvg-chno="73" channel-id="73",LA TELE FR HD
 rtp://239.186.70.161:10000
-#EXTINF:-1 tvg-id="LCI" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="LCI" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="75" channel-id="75",LCI HD La Chaine Info HD
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="http://static.epg.best/fr/LCI.fr.png" tvg-chno="75" channel-id="75",LCI HD La Chaine Info HD
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",lemanbleu
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",lemanbleu
 rtp://239.186.64.89:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="77" channel-id="77",lemanbleu HD
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="http://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="77" channel-id="77",lemanbleu HD
 rtp://239.186.70.39:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="78" channel-id="78",lfm TV HD
 rtp://239.186.70.11:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="87" channel-id="79",One tv CH HD
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="" tvg-logo="" tvg-chno="87" channel-id="79",One tv CH HD
 rtp://239.186.70.12:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv dieu tv
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv dieu tv
 rtp://239.186.64.102:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="82" channel-id="82",maxtv dieu tv HD
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="82" channel-id="82",maxtv dieu tv HD
 rtp://239.186.68.199:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
 rtp://239.186.66.198:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="86" channel-id="86",nrtv HD
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="86" channel-id="86",nrtv HD
 rtp://239.186.70.66:10000
 #EXTINF:-1 tvg-id="RougeTV" tvg-name="Rouge TV CH" tvg-logo="http://static.epg.best/ch/RougeTV.ch.png" tvg-chno="88" channel-id="88",rougeTV
 rtp://239.186.64.145:10000
 #EXTINF:-1 tvg-id="RougeTV" tvg-name="Rouge TV CH" tvg-logo="http://static.epg.best/ch/RougeTV.ch.png" tvg-chno="89" channel-id="89",rougeTV HD
 rtp://239.186.68.253:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="90" channel-id="90",RTL9 CH
 rtp://239.186.64.155:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="91" channel-id="91",RTL9 CH HD
+#EXTINF:-1 tvg-id="RTL9.lu@SD" tvg-name="" tvg-logo="" tvg-chno="91" channel-id="91",RTL9 CH HD
 rtp://239.186.68.242:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="92" channel-id="92",GENEVE REGION TELEVISION
+#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="" tvg-logo="" tvg-chno="92" channel-id="92",GENEVE REGION TELEVISION
 rtp://239.186.64.69:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="93" channel-id="93",GENEVE REGION TELEVISION HD
+#EXTINF:-1 tvg-id="GeneveRegionTelevision.fr@SD" tvg-name="" tvg-logo="" tvg-chno="93" channel-id="93",GENEVE REGION TELEVISION HD
 rtp://239.186.70.155:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="94" channel-id="94",blue Zoom F
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="" tvg-logo="" tvg-chno="94" channel-id="94",blue Zoom F
 rtp://239.186.64.111:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="95" channel-id="95",blue Zoom F HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="" tvg-logo="" tvg-chno="95" channel-id="95",blue Zoom F HD
 rtp://239.186.68.244:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="96" channel-id="96",TV5MONDE EUROPE
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="96" channel-id="96",TV5MONDE EUROPE
 rtp://239.186.64.71:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="97" channel-id="97",TV5MONDE EUROPE HD
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="http://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="97" channel-id="97",TV5MONDE EUROPE HD
 rtp://239.186.84.54:10000
-#EXTINF:-1 tvg-id="TV5MONDE" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="98" channel-id="98",TV5MONDE FRANCE BELGIQUE SUISSE
 rtp://239.186.64.150:10000
-#EXTINF:-1 tvg-id="TV5MONDE" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="http://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="99" channel-id="99",TV5MONDE FRANCE BELGIQUE SUISSE HD
 rtp://239.186.70.41:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="100" channel-id="100",tvm3
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="" tvg-logo="" tvg-chno="100" channel-id="100",tvm3
 rtp://239.186.64.98:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="101" channel-id="101",tvm3 HD
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="" tvg-logo="" tvg-chno="101" channel-id="101",tvm3 HD
 rtp://239.186.70.21:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="102" channel-id="102",TV Onex HD
+#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="" tvg-logo="" tvg-chno="102" channel-id="102",TV Onex HD
 rtp://239.186.70.132:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="AlJazeeraEnglish.qa" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="115" channel-id="115",Al Jazeera E
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="115" channel-id="115",Al Jazeera E
 rtp://239.186.64.173:10000
-#EXTINF:-1 tvg-id="AlJazeeraEnglish.qa" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",Al Jazeera E HD
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="http://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",Al Jazeera E HD
 rtp://239.186.68.171:10000
-#EXTINF:-1 tvg-id="BBC1.uk" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC One
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC One
 rtp://239.186.64.51:10000
-#EXTINF:-1 tvg-id="BBC1.uk" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="119" channel-id="119",BBC One HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="http://static.epg.best/uk/BBC1.uk.png" tvg-chno="119" channel-id="119",BBC One HD
 rtp://239.186.68.43:10000
-#EXTINF:-1 tvg-id="BBC2.uk" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC Two
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC Two
 rtp://239.186.64.165:10000
-#EXTINF:-1 tvg-id="BBC2.uk" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="121" channel-id="121",BBC Two HD
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="http://static.epg.best/uk/BBC2.uk.png" tvg-chno="121" channel-id="121",BBC Two HD
 rtp://239.186.68.41:10000
-#EXTINF:-1 tvg-id="CBBC.uk" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC
 rtp://239.186.64.166:10000
-#EXTINF:-1 tvg-id="CBBC.uk" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="123" channel-id="123",BBC CBBC HD
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="http://static.epg.best/uk/CBBC.uk.png" tvg-chno="123" channel-id="123",BBC CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="BBC4.uk" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
+#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC Four/ BBC CBeebies
 rtp://239.186.64.52:10000
-#EXTINF:-1 tvg-id="BBC4.uk" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="http://static.epg.best/uk/BBC4.uk.png" tvg-chno="125" channel-id="125",BBC Four HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
-#EXTINF:-1 tvg-id="CBeebies.uk" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
-#EXTINF:-1 tvg-id="CBeebies.uk" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="127" channel-id="127",BBC CBeebies HD / BBC Four HD
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="http://static.epg.best/uk/CBeebies.uk.png" tvg-chno="127" channel-id="127",BBC CBeebies HD / BBC Four HD
 rtp://239.186.68.152:10000
-#EXTINF:-1 tvg-id="BBCNews.uk" tvg-name="BBC News UK" tvg-logo="http://static.epg.best/uk/BBCNews.uk.png" tvg-chno="128" channel-id="128",BBC News HD
+#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC News UK" tvg-logo="http://static.epg.best/uk/BBCNews.uk.png" tvg-chno="128" channel-id="128",BBC News HD
 rtp://239.186.68.160:10000
-#EXTINF:-1 tvg-id="BBCWorldNews.uk" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="129" channel-id="129",BBC World News
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="129" channel-id="129",BBC World News
 rtp://239.186.64.176:10000
-#EXTINF:-1 tvg-id="BBCWorldNews.uk" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="130" channel-id="130",BBC World News HD
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News UK" tvg-logo="http://static.epg.best/uk/BBCWorldNews.uk.png" tvg-chno="130" channel-id="130",BBC World News HD
 rtp://239.186.68.214:10000
-#EXTINF:-1 tvg-id="BloombergTV.uk" tvg-name="Bloomberg TV UK" tvg-logo="http://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="http://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
 rtp://239.186.64.177:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="132" channel-id="132",THE BOX
 rtp://239.186.66.142:10000
-#EXTINF:-1 tvg-id="CGTN.au" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN E
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN E
 rtp://239.186.66.114:10000
-#EXTINF:-1 tvg-id="CGTN.au" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="136" channel-id="136",CGTN E HD
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="http://static.epg.best/au/CGTN.au.png" tvg-chno="136" channel-id="136",CGTN E HD
 rtp://239.186.70.90:10000
-#EXTINF:-1 tvg-id="Channel4.uk" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
 rtp://239.186.64.183:10000
-#EXTINF:-1 tvg-id="Channel4.uk" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="138" channel-id="138",Channel4 HD
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="http://static.epg.best/uk/Channel4.uk.png" tvg-chno="138" channel-id="138",Channel4 HD
 rtp://239.186.68.40:10000
-#EXTINF:-1 tvg-id="ChartShow.uk" tvg-name="Chart Show UK" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Chart Show UK" tvg-logo="http://static.epg.best/uk/ChartShow.uk.png" tvg-chno="139" channel-id="139",CHART SHOW TV
 rtp://239.186.66.115:10000
-#EXTINF:-1 ,NOW 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD" ,NOW 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 ,NOW 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" ,NOW 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="140" channel-id="140",NOW 90s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="" tvg-logo="" tvg-chno="140" channel-id="140",NOW 90s
 rtp://239.186.66.133:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk" tvg-name="Clubland TV UK" tvg-logo="http://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="141" channel-id="141",clubland
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="http://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="141" channel-id="141",clubland
 rtp://239.186.66.116:10000
-#EXTINF:-1 tvg-id="CNBC.uk" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC UK
+#EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC UK
 rtp://239.186.64.167:10000
-#EXTINF:-1 tvg-id="CNBC.uk" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="143" channel-id="143",CNBC UK HD
+#EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="http://static.epg.best/uk/CNBC.uk.png" tvg-chno="143" channel-id="143",CNBC UK HD
 rtp://239.186.70.224:10000
-#EXTINF:-1 tvg-id="CNN.uk" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
 rtp://239.186.64.175:10000
-#EXTINF:-1 tvg-id="CNN.uk" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="145" channel-id="145",CNN International HD
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="http://static.epg.best/uk/CNN.uk.png" tvg-chno="145" channel-id="145",CNN International HD
 rtp://239.186.70.23:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="207" channel-id="207",DW Deutsche Welle English
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="Drama.uk" tvg-name="Drama UK" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
+#EXTINF:-1 tvg-id="902" tvg-name="Drama UK" tvg-logo="http://static.epg.best/uk/Drama.uk.png" tvg-chno="146" channel-id="146",DRAMA
 rtp://239.186.66.140:10000
-#EXTINF:-1 tvg-id="E4.uk" tvg-name="E4 UK" tvg-logo="http://static.epg.best/uk/E4.uk.png" tvg-chno="147" channel-id="147",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="http://static.epg.best/uk/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuroNews.uk" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews. E
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews. E
 rtp://239.186.64.178:10000
-#EXTINF:-1 tvg-id="EuroNews.uk" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="149" channel-id="149",euronews. E HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="http://static.epg.best/uk/EuroNews.uk.png" tvg-chno="149" channel-id="149",euronews. E HD
 rtp://239.186.70.105:10000
-#EXTINF:-1 tvg-id="FashionTV.fr" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
+#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
 rtp://239.186.64.174:10000
-#EXTINF:-1 tvg-id="FashionTV.fr" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="151" channel-id="151",Fashion TV HD
+#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="http://static.epg.best/fr/FashionTV.fr.png" tvg-chno="151" channel-id="151",Fashion TV HD
 rtp://239.186.70.200:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="http://static.epg.best/uk/Film4.uk.png" tvg-chno="152" channel-id="152",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="FiveUSA.uk" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="153" channel-id="153",Five
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="153" channel-id="153",Five
 rtp://239.186.64.184:10000
-#EXTINF:-1 tvg-id="FiveUSA.uk" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="154" channel-id="154",Five HD
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="154" channel-id="154",Five HD
 rtp://239.186.70.151:10000
-#EXTINF:-1 tvg-id="FoodNetwork.uk" tvg-name="Food Network UK" tvg-logo="http://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="http://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="157" channel-id="157",i24 NEWS E
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="" tvg-logo="" tvg-chno="157" channel-id="157",i24 NEWS E
 rtp://239.186.66.126:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="158" channel-id="158",i24 NEWS E HD
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="" tvg-logo="" tvg-chno="158" channel-id="158",i24 NEWS E HD
 rtp://239.186.68.140:10000
-#EXTINF:-1 tvg-id="ITV1Anglia.uk" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="159" channel-id="159",itv
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="159" channel-id="159",itv
 rtp://239.186.64.169:10000
-#EXTINF:-1 tvg-id="ITV1Anglia.uk" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="160" channel-id="160",itv HD
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="http://static.epg.best/uk/ITV1Anglia.uk.png" tvg-chno="160" channel-id="160",itv HD
 rtp://239.186.68.42:10000
-#EXTINF:-1 tvg-id="ITV2.uk" tvg-name="ITV2 UK" tvg-logo="http://static.epg.best/uk/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="http://static.epg.best/uk/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
 rtp://239.186.64.170:10000
-#EXTINF:-1 tvg-id="ITV3.uk" tvg-name="ITV3 UK" tvg-logo="http://static.epg.best/uk/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="http://static.epg.best/uk/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
 rtp://239.186.64.180:10000
-#EXTINF:-1 tvg-id="ITV4.uk" tvg-name="ITV4 UK" tvg-logo="http://static.epg.best/uk/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="http://static.epg.best/uk/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
 rtp://239.186.64.171:10000
-#EXTINF:-1 tvg-id="ITVBe.uk" tvg-name="ITVBe UK" tvg-logo="http://static.epg.best/uk/ITVBe.uk.png" tvg-chno="164" channel-id="164",itv Be.
+#EXTINF:-1 tvg-id="ITVBe.uk@SD" tvg-name="ITVBe UK" tvg-logo="http://static.epg.best/uk/ITVBe.uk.png" tvg-chno="164" channel-id="164",itv Be.
 rtp://239.186.74.14:10000
 #EXTINF:-1 tvg-id="Kerrang.uk" tvg-name="Kerrang! TV UK" tvg-logo="http://static.epg.best/uk/Kerrang.uk.png" tvg-chno="165" channel-id="165",KERRANG!
 rtp://239.186.64.105:10000
 #EXTINF:-1 tvg-id="KissTV.uk" tvg-name="Kiss TV UK" tvg-logo="http://static.epg.best/uk/KissTV.uk.png" tvg-chno="166" channel-id="166",Kiss TV
 rtp://239.186.66.128:10000
-#EXTINF:-1 tvg-id="More4.uk" tvg-name="More4 UK" tvg-logo="http://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="http://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorld.jp" tvg-name="NHK World JP" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World JP" tvg-logo="http://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK WORLD HD
 rtp://239.186.68.172:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="169" channel-id="169",RT Russia Today
 rtp://239.186.66.139:10000
-#EXTINF:-1 tvg-id="SkyNews.uk" tvg-name="Sky News UK" tvg-logo="http://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="http://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="" channel-id="",5Spike
+#EXTINF:-1 tvg-id="1410" tvg-name="" tvg-logo="" tvg-chno="" channel-id="",5Spike
 rtp://239.186.66.244:10000
-#EXTINF:-1 tvg-id="FiveUSA.uk" tvg-name="5USA UK" tvg-logo="http://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="http://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk" tvg-name="BBC Parliament UK" tvg-logo="http://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC Parliament
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament UK" tvg-logo="http://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC Parliament
 rtp://239.186.74.25:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk" tvg-name="PBS America UK" tvg-logo="http://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="http://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America
 rtp://239.186.66.243:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="3Plus.ch" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
+#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
 rtp://239.186.64.56:10000
-#EXTINF:-1 tvg-id="3Plus.ch" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
+#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="http://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
 rtp://239.186.68.14:10000
-#EXTINF:-1 tvg-id="3sat.at" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
+#EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
 rtp://239.186.64.55:10000
-#EXTINF:-1 tvg-id="3sat.at" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
+#EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="http://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
 rtp://233.35.254.209:1234
-#EXTINF:-1 tvg-id="4Plus.ch" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
+#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
 rtp://239.186.64.142:10000
-#EXTINF:-1 tvg-id="4Plus.ch" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
+#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="http://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
 rtp://239.186.68.142:10000
-#EXTINF:-1 tvg-id="5Plus.ch" tvg-name="5+ CH" tvg-logo="http://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
+#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+ CH" tvg-logo="http://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
 rtp://239.186.68.195:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AlpenlandTV
 rtp://239.186.64.112:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="180" channel-id="180",AlpenlandTV HD
 rtp://239.186.70.9:10000
-#EXTINF:-1 tvg-id="Anixe.de" tvg-name="Anixe DE" tvg-logo="http://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
+#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe DE" tvg-logo="http://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
 rtp://239.186.68.7:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="182" channel-id="182",ARD1 Das Erste
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="" tvg-logo="" tvg-chno="182" channel-id="182",ARD1 Das Erste
 rtp://239.186.64.11:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="183" channel-id="183",ARD1 Das Erste HD
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="" tvg-logo="" tvg-chno="183" channel-id="183",ARD1 Das Erste HD
 rtp://239.186.68.9:10000
-#EXTINF:-1 tvg-id="ARDalpha.de" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="195",ARD alpha
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="195",ARD alpha
 rtp://239.186.64.119:10000
-#EXTINF:-1 tvg-id="ARDalpha.de" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="196",ARD alpha HD
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="http://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="196",ARD alpha HD
 rtp://239.186.70.194:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="185" channel-id="185",ARD one
 rtp://239.186.64.121:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="186" channel-id="186",ARD one HD
 rtp://239.186.68.154:10000
-#EXTINF:-1 tvg-id="ARTE.at" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="187" channel-id="187",arte D
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="187" channel-id="187",arte D
 rtp://239.186.64.23:10000
-#EXTINF:-1 tvg-id="ARTE.at" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="188" channel-id="188",arte D HD
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte AT" tvg-logo="http://static.epg.best/at/ARTE.at.png" tvg-chno="188" channel-id="188",arte D HD
 rtp://239.186.68.11:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV HD
+#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV HD
 rtp://239.186.70.117:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="190" channel-id="190",BEATZ HD / radio Pilatus HD
+#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="190" channel-id="190",BEATZ HD / radio Pilatus HD
 rtp://239.186.68.104:10000
-#EXTINF:-1 tvg-id="BibelTV.de" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
 rtp://239.186.64.131:10000
-#EXTINF:-1 tvg-id="BibelTV.de" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="http://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
 rtp://239.186.68.148:10000
-#EXTINF:-1 tvg-id="RegioTVBodensee.de" tvg-name="Regio TV Bodensee DE" tvg-logo="http://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
+#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Regio TV Bodensee DE" tvg-logo="http://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
 rtp://239.186.68.143:10000
-#EXTINF:-1 tvg-id="BR.de" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
 rtp://239.186.64.26:10000
-#EXTINF:-1 tvg-id="BR.de" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="http://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
 rtp://239.186.68.26:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="198" channel-id="198",Channel55 D
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="" tvg-logo="" tvg-chno="198" channel-id="198",Channel55 D
 rtp://239.186.66.238:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="199" channel-id="199",Channel55 D HD
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="" tvg-logo="" tvg-chno="199" channel-id="199",Channel55 D HD
 rtp://239.186.70.103:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="200" channel-id="200",Davos Klosters HD
+#EXTINF:-1 tvg-id="116" tvg-name="" tvg-logo="" tvg-chno="200" channel-id="200",Davos Klosters HD
 rtp://239.186.68.216:10000
-#EXTINF:-1 tvg-id="DeLuxeMusic.de" tvg-name="Deluxe Music DE" tvg-logo="http://static.epg.best/de/DeLuxeMusic.de.png" tvg-chno="201" channel-id="201",DELUXE MUSIC
+#EXTINF:-1 tvg-id="120" tvg-name="Deluxe Music DE" tvg-logo="http://static.epg.best/de/DeLuxeMusic.de.png" tvg-chno="201" channel-id="201",DELUXE MUSIC
 rtp://239.186.64.132:10000
-#EXTINF:-1 tvg-id="DeutschesMusikFernsehen.de" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="http://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",Deutsches Musik Fernsehen
 rtp://239.186.66.118:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de" tvg-name="Disney Channel DE" tvg-logo="http://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel D
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="http://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel D
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="DisneyCinema.de" tvg-name="Disney Cinema DE" tvg-logo="http://static.epg.best/de/DisneyCinema.de.png" tvg-chno="156" channel-id="156",Disney Cinema D
+#EXTINF:-1 tvg-id="1068" tvg-name="Disney Cinema DE" tvg-logo="http://static.epg.best/de/DisneyCinema.de.png" tvg-chno="156" channel-id="156",Disney Cinema D
 rtp://239.186.64.218:10000
-#EXTINF:-1 tvg-id="DMax.de" tvg-name="Dmax DE" tvg-logo="http://static.epg.best/de/DMax.de.png" tvg-chno="204" channel-id="204",DMAX Schweiz
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="Dmax DE" tvg-logo="http://static.epg.best/de/DMax.de.png" tvg-chno="204" channel-id="204",DMAX Schweiz
 rtp://239.186.64.34:10000
-#EXTINF:-1 tvg-id="MoreThanSport.de" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="205" channel-id="205",More Than Sport
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="205" channel-id="205",More Than Sport
 rtp://239.186.66.241:10000
-#EXTINF:-1 tvg-id="MoreThanSport.de" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="206" channel-id="206",More Than Sport HD
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="MoreThanSport DE" tvg-logo="http://static.epg.best/de/morethansport.de.png" tvg-chno="206" channel-id="206",More Than Sport HD
 rtp://239.186.70.28:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="207" channel-id="207",DW Deutsche Welle Deutsch
 rtp://239.186.74.26:10000
-#EXTINF:-1 tvg-id="Euronews.de" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
 rtp://239.186.64.137:10000
-#EXTINF:-1 tvg-id="Euronews.de" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="http://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
 rtp://239.186.70.101:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx
 rtp://239.186.66.197:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx HD
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" tvg-name="" tvg-logo="" tvg-chno="212" channel-id="212",Folx HD
 rtp://239.186.68.121:10000/
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="473" channel-id="473",FOX D
+#EXTINF:-1 tvg-id="1069" tvg-name="" tvg-logo="" tvg-chno="473" channel-id="473",FOX D
 rtp://239.186.64.213:10000
 #EXTINF:-1 tvg-id="GoTV.at" tvg-name="Go TV" tvg-logo="http://static.epg.best/at/GoTV.at.png" tvg-chno="213" channel-id="213",gotv
 rtp://239.186.64.141:10000
-#EXTINF:-1 tvg-id="HopeChannelInt.us" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="214" channel-id="214",HopeChannel
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="214" channel-id="214",HopeChannel
 rtp://239.186.64.115:10000
-#EXTINF:-1 tvg-id="HopeChannelInt.us" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="215" channel-id="215",HopeChannel HD
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. US" tvg-logo="http://static.epg.best/us/HopeChannelInt.us.png" tvg-chno="215" channel-id="215",HopeChannel HD
 rtp://239.186.68.251:10000
-#EXTINF:-1 tvg-id="HR.de" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
 rtp://239.186.64.28:10000
-#EXTINF:-1 tvg-id="HR.de" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="http://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
 rtp://239.186.68.156:10000
-#EXTINF:-1 tvg-id="HSE24.de" tvg-name="HSE24 DE" tvg-logo="http://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE24
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE24 DE" tvg-logo="http://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE24
 rtp://239.186.64.123:10000
 #EXTINF:-1 tvg-id="Insight.uk" tvg-name="Insight UK" tvg-logo="http://static.epg.best/uk/Insight.uk.png" tvg-chno="219" channel-id="219",Insight.tv HD
 rtp://239.186.70.75:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="http://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins
 rtp://239.186.64.20:10000
-#EXTINF:-1 tvg-id="Kanal9.ch" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
 rtp://239.186.64.109:10000
-#EXTINF:-1 tvg-id="Kanal9.ch" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="http://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
 rtp://239.186.68.145:10000
-#EXTINF:-1 tvg-id="Kika.de" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
 rtp://239.186.64.31:10000
-#EXTINF:-1 tvg-id="Kika.de" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="http://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
 rtp://239.186.68.28:10000
-#EXTINF:-1 tvg-id="KTV.de" tvg-name="K-TV DE" tvg-logo="http://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
+#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="http://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
 rtp://239.186.64.133:10000
-#EXTINF:-1 tvg-id="Loly.ch" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="221" channel-id="221",LOLY
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="221" channel-id="221",LOLY
 rtp://239.186.66.231:10000
-#EXTINF:-1 tvg-id="Loly.ch" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="222" channel-id="222",LOLY HD
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="http://static.epg.best/ch/Loly.ch.png" tvg-chno="222" channel-id="222",LOLY HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
-#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="http://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie TV
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie TV
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="MTVGermany.de" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="232" channel-id="232",MTV CH
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="232" channel-id="232",MTV CH
 rtp://239.186.64.32:10000
-#EXTINF:-1 tvg-id="MTVGermany.de" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="233" channel-id="233",MTV CH HD
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV DE" tvg-logo="http://static.epg.best/de/MTVGermany.de.png" tvg-chno="233" channel-id="233",MTV CH HD
 rtp://239.186.68.174:10000
-#EXTINF:-1 tvg-id="Music24.il" tvg-name="Music 24 IL" tvg-logo="http://static.epg.best/il/Music24.il.png" tvg-chno="234" channel-id="234",musig24 HD
+#EXTINF:-1 tvg-id="272" tvg-name="Music 24 IL" tvg-logo="http://static.epg.best/il/Music24.il.png" tvg-chno="234" channel-id="234",musig24 HD
 rtp://239.186.68.207:10000
-#EXTINF:-1 tvg-id="N24Doku.de" tvg-name="N24 Doku DE" tvg-logo="http://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="http://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
-#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="http://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="238" channel-id="238",nick schweiz
 rtp://239.186.64.186:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="239" channel-id="239",nick schweiz HD
 rtp://239.186.68.175:10000
-#EXTINF:-1 tvg-id="RTLNitro.de" tvg-name="RTL Nitro DE" tvg-logo="http://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="http://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
-#EXTINF:-1 tvg-id="ntv.de" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
 rtp://239.186.64.29:10000
-#EXTINF:-1 tvg-id="ntv.de" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="242" channel-id="242",ntv HD
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="http://static.epg.best/de/ntv.de.png" tvg-chno="242" channel-id="242",ntv HD
 rtp://239.186.68.146:10000
-#EXTINF:-1 tvg-id="ORF1.at" tvg-name="ORF 1" tvg-logo="http://static.epg.best/at/ORF1.at.png" tvg-chno="243" channel-id="243",ORF1
+#EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="http://static.epg.best/at/ORF1.at.png" tvg-chno="243" channel-id="243",ORF1
 rtp://239.186.64.13:10000
-#EXTINF:-1 tvg-id="ORF1.at" tvg-name="ORF 1" tvg-logo="http://static.epg.best/at/ORF1.at.png" tvg-chno="244" channel-id="244",ORF1 HD
+#EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="http://static.epg.best/at/ORF1.at.png" tvg-chno="244" channel-id="244",ORF1 HD
 rtp://239.186.68.12:10000
-#EXTINF:-1 tvg-id="ORF2.at" tvg-name="ORF 2" tvg-logo="http://static.epg.best/at/ORF2.at.png" tvg-chno="245" channel-id="245",ORF2
+#EXTINF:-1 tvg-id="ORF2.at@SD" tvg-name="ORF 2" tvg-logo="http://static.epg.best/at/ORF2.at.png" tvg-chno="245" channel-id="245",ORF2
 rtp://239.186.64.14:10000
-#EXTINF:-1 tvg-id="ORF2.at" tvg-name="ORF 2" tvg-logo="http://static.epg.best/at/ORF2.at.png" tvg-chno="246" channel-id="246",ORF2 HD
+#EXTINF:-1 tvg-id="ORF2.at@SD" tvg-name="ORF 2" tvg-logo="http://static.epg.best/at/ORF2.at.png" tvg-chno="246" channel-id="246",ORF2 HD
 rtp://239.186.68.13:10000
-#EXTINF:-1 tvg-id="ORF3.at" tvg-name="ORF 3" tvg-logo="http://static.epg.best/at/ORF3.at.png" tvg-chno="247" channel-id="247",ORF3
+#EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="http://static.epg.best/at/ORF3.at.png" tvg-chno="247" channel-id="247",ORF3
 rtp://239.186.64.86:10000
-#EXTINF:-1 tvg-id="ORF3.at" tvg-name="ORF 3" tvg-logo="http://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
+#EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="http://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="Phoenix.de" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
 rtp://239.186.64.65:10000
-#EXTINF:-1 tvg-id="Phoenix.de" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="http://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
 rtp://239.186.68.30:10000
-#EXTINF:-1 tvg-id="Pro7.de" tvg-name="Pro 7 DE" tvg-logo="http://static.epg.best/de/Pro7.de.png" tvg-chno="251" channel-id="251",Pro7
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro 7 DE" tvg-logo="http://static.epg.best/de/Pro7.de.png" tvg-chno="251" channel-id="251",Pro7
 rtp://239.186.64.19:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="254" channel-id="254",Puls aCHT HD
 rtp://239.186.68.191:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="" channel-id="254",QS24 QantiSana HD
 rtp://233.35.254.211:1234
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="255" channel-id="255",R9 Oesterreich HD
+#EXTINF:-1 tvg-id="R9.at@SD" tvg-name="" tvg-logo="" tvg-chno="255" channel-id="255",R9 Oesterreich HD
 rtp://239.186.68.248:10000
-#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
+#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
 rtp://239.186.64.126:10000
-#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
+#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="http://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
 rtp://239.186.68.157:10000
-#EXTINF:-1 tvg-id="RegioTV.de" tvg-name="Regio TV DE" tvg-logo="http://static.epg.best/de/RegioTV.de.png" tvg-chno="258" channel-id="258",regioTVplus HD
+#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="Regio TV DE" tvg-logo="http://static.epg.best/de/RegioTV.de.png" tvg-chno="258" channel-id="258",regioTVplus HD
 rtp://239.186.70.40:10000
-#EXTINF:-1 tvg-id="RTL.de" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="RTL.de" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH HD
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="http://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH HD
 rtp://233.35.254.237:1234
-#EXTINF:-1 tvg-id="RTL2.de" tvg-name="RTL 2 DE" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="http://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL2 CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="RTLPlus.de" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL Plus DE" tvg-logo="http://static.epg.best/de/RTLPlus.de.png" tvg-chno="262" channel-id="262",RTLplus
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="S1.ch" tvg-name="S1 CH" tvg-logo="http://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
+#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1 CH" tvg-logo="http://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
-#EXTINF:-1 tvg-id="Sat1.de" tvg-name="Sat 1 DE" tvg-logo="http://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="http://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
 rtp://239.186.64.18:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="267" channel-id="267",Schweiz5
+#EXTINF:-1 tvg-id="378" tvg-name="" tvg-logo="" tvg-chno="267" channel-id="267",Schweiz5
 rtp://239.186.64.101:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="268" channel-id="268",Schweiz5 HD
+#EXTINF:-1 tvg-id="378" tvg-name="" tvg-logo="" tvg-chno="268" channel-id="268",Schweiz5 HD
 rtp://239.186.68.245:10000
-#EXTINF:-1 tvg-id="ServusTV.at" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV DEUTSCHLAND CH
+#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV DEUTSCHLAND CH
 rtp://239.186.64.136:10000
-#EXTINF:-1 tvg-id="ServusTV.at" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="270" channel-id="270",ServusTV DEUTSCHLAND CH HD
+#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="http://static.epg.best/at/ServusTV.at.png" tvg-chno="270" channel-id="270",ServusTV DEUTSCHLAND CH HD
 rtp://233.35.254.129:1234
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
+#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
 rtp://239.186.66.146:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="272" channel-id="272",SessionNationalrat HD
+#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="272" channel-id="272",SessionNationalrat HD
 rtp://239.186.70.127:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="273" channel-id="273",SessionStaenderat
 rtp://239.186.64.124:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="274" channel-id="274",SessionStaendenrat HD
 rtp://239.186.70.128:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
 rtp://239.186.64.97:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="277" channel-id="277",SHf HD
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="277" channel-id="277",SHf HD
 rtp://239.186.68.139:10000
-#EXTINF:-1 tvg-id="sixx.de" tvg-name="Sixx DE" tvg-logo="http://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="http://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
 rtp://239.186.64.70:10000
-#EXTINF:-1 tvg-id="Sport1.de" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",sport1 CH
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",sport1 CH
 rtp://239.186.64.64:10000
-#EXTINF:-1 tvg-id="Sport1.de" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",sport1 CH HD
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="http://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",sport1 CH HD
 rtp://239.186.68.159:10000
-#EXTINF:-1 tvg-id="SRF1.ch" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
 rtp://239.186.64.2:10000
-#EXTINF:-1 tvg-id="SRF1.ch" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 HD
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="http://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 HD
 rtp://239.186.68.1:10000
-#EXTINF:-1 tvg-id="SRF2.ch" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
 rtp://239.186.64.3:10000
-#EXTINF:-1 tvg-id="SRF2.ch" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 HD SRF zwei HD
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="http://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 HD SRF zwei HD
 rtp://239.186.68.2:10000
-#EXTINF:-1 tvg-id="SRFInfo.ch" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
 rtp://239.186.64.4:10000
-#EXTINF:-1 tvg-id="SRFInfo.ch" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info HD
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="http://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info HD
 rtp://239.186.68.202:10000
-#EXTINF:-1 tvg-id="StarTV.ch" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
 rtp://239.186.64.87:10000
-#EXTINF:-1 tvg-id="StarTV.ch" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",Star TV HD
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="http://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",Star TV HD
 rtp://239.186.68.188:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="289" channel-id="289",GAMETV HD
+#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="289" channel-id="289",GAMETV HD
 rtp://239.186.70.10:10000
-#EXTINF:-1 tvg-id="SuperRTL.de" tvg-name="Super RTL DE" tvg-logo="http://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",SUPER RTL
+#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL DE" tvg-logo="http://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",SUPER RTL
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="291" channel-id="291",Swiss 1 HD
+#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="" tvg-logo="" tvg-chno="291" channel-id="291",Swiss 1 HD
 rtp://239.186.68.97:10000
-#EXTINF:-1 tvg-id="SWRSR.de" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="292" channel-id="292",SWR >>
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="292" channel-id="292",SWR >>
 rtp://239.186.64.27:10000
-#EXTINF:-1 tvg-id="SWRSR.de" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >> HD
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="http://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >> HD
 rtp://239.186.68.25:10000
-#EXTINF:-1 tvg-id="Tagesschau24.de" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="294" channel-id="294",Tagesschau24
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="294" channel-id="294",Tagesschau24
 rtp://239.186.64.120:10000
-#EXTINF:-1 tvg-id="Tagesschau24.de" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24 HD
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="http://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24 HD
 rtp://239.186.68.161:10000
-#EXTINF:-1 tvg-id="Tele1.ch" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="296" channel-id="296",Tele1
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="296" channel-id="296",Tele1
 rtp://239.186.64.91:10000
-#EXTINF:-1 tvg-id="Tele1.ch" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1 HD
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="http://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1 HD
 rtp://239.186.68.176:10000
-#EXTINF:-1 tvg-id="Tele5.de" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="298" channel-id="298",TELE5
+#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="298" channel-id="298",TELE5
 rtp://239.186.64.22:10000
-#EXTINF:-1 tvg-id="Tele5.de" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="299" channel-id="299",TELE5 HD
+#EXTINF:-1 tvg-id="TELE5.de@SD" tvg-name="Tele 5 DE" tvg-logo="http://static.epg.best/de/Tele5.de.png" tvg-chno="299" channel-id="299",TELE5 HD
 rtp://239.186.64.22:10000
-#EXTINF:-1 tvg-id="TeleBaern.ch" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",TELE BAERN
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",TELE BAERN
 rtp://239.186.64.60:10000
-#EXTINF:-1 tvg-id="TeleBaern.ch" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",TELE BAERN HD
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="http://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",TELE BAERN HD
 rtp://239.186.68.38:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="302" channel-id="302",TeleBielingue
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="" tvg-logo="" tvg-chno="302" channel-id="302",TeleBielingue
 rtp://239.186.64.95:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="303" channel-id="303",TeleBielingue HD
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="" tvg-logo="" tvg-chno="303" channel-id="303",TeleBielingue HD
 rtp://239.186.70.82:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="304" channel-id="304",TELE D HD
+#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="" tvg-logo="" tvg-chno="304" channel-id="304",TELE D HD
 rtp://239.186.68.217:10000
-#EXTINF:-1 tvg-id="TeleM1.ch" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
 rtp://239.186.64.90:10000
-#EXTINF:-1 tvg-id="TeleM1.ch" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="http://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
 rtp://239.186.68.102:10000
-#EXTINF:-1 tvg-id="TeleTop.ch" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
 rtp://239.186.64.96:10000
-#EXTINF:-1 tvg-id="TeleTop.ch" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="http://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
 rtp://239.186.68.252:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
 rtp://239.186.64.103:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="310" channel-id="310",TELEZ HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="310" channel-id="310",TELEZ HD
 rtp://239.186.68.205:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="311" channel-id="311",Tele Zentralschweiz
+#EXTINF:-1 tvg-id="TeleZentralschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="311" channel-id="311",Tele Zentralschweiz
 rtp://239.186.68.166:10000
-#EXTINF:-1 tvg-id="TeleZueri.ch" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",TELE ZURI
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",TELE ZURI
 rtp://239.186.64.9:10000
-#EXTINF:-1 tvg-id="TeleZueri.ch" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="http://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
 rtp://239.186.68.189:10000
-#EXTINF:-1 tvg-id="TeleBasel.ch" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
 rtp://239.186.64.88:10000
-#EXTINF:-1 tvg-id="TeleBasel.ch" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="http://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
 rtp://239.186.68.206:10000
-#EXTINF:-1 tvg-id="blueZoom.ch" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="316" channel-id="316",blue zoom D
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="316" channel-id="316",blue zoom D
 rtp://239.186.66.129:10000
-#EXTINF:-1 tvg-id="blueZoom.ch" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="317" channel-id="317",blue zoom D HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom CH" tvg-logo="http://static.epg.best/ch/TeleclubZoom.ch.png" tvg-chno="317" channel-id="317",blue zoom D HD
 rtp://239.186.68.155:10000
-#EXTINF:-1 tvg-id="TLC.de" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="318" channel-id="318",TLC CH
+#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="318" channel-id="318",TLC CH
 rtp://239.186.66.175:10000
-#EXTINF:-1 tvg-id="TLC.de" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="319" channel-id="319",TLC CH HD
+#EXTINF:-1 tvg-id="TLC.de@SD" tvg-name="TLC DE" tvg-logo="http://static.epg.best/de/TLC.de.png" tvg-chno="319" channel-id="319",TLC CH HD
 rtp://239.186.70.67:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de" tvg-name="Toggo plus DE" tvg-logo="http://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="http://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="321" channel-id="321",TSO Suedostchweiz
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="321" channel-id="321",TSO Suedostchweiz
 rtp://239.186.64.100:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="322" channel-id="322",TSO Suedostchweiz HD
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="" tvg-logo="" tvg-chno="322" channel-id="322",TSO Suedostchweiz HD
 rtp://239.186.68.218:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="323" channel-id="323",TV4TNG HD
 rtp://239.186.70.126:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="324" channel-id="324",TV Oberwallis HD
+#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="" tvg-logo="" tvg-chno="324" channel-id="324",TV Oberwallis HD
 rtp://239.186.70.5:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="325" channel-id="325",TV Rheintal
+#EXTINF:-1 tvg-id="TVRheintal.ch@SD" tvg-name="" tvg-logo="" tvg-chno="325" channel-id="325",TV Rheintal
 rtp://239.186.64.93:10000
-#EXTINF:-1 tvg-id="TV24.ch" tvg-name="TV24 CH" tvg-logo="http://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
+#EXTINF:-1 tvg-id="1910" tvg-name="TV24 CH" tvg-logo="http://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
 rtp://239.186.68.190:10000
 #EXTINF:-1 tvg-id="TV25.ch" tvg-name="TV 25 CH" tvg-logo="http://static.epg.best/ch/TV25.ch.png" tvg-chno="327" channel-id="327",TV25 HD
 rtp://239.186.70.20:10000
-#EXTINF:-1 tvg-id="TVO.ch" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
 rtp://239.186.64.94:10000
-#EXTINF:-1 tvg-id="TVO.ch" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="http://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
 rtp://239.186.70.4:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="330" channel-id="330",vision tv
+#EXTINF:-1 tvg-id="917" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="330" channel-id="330",vision tv
 rtp://239.186.64.62:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="331" channel-id="331",vision tv HD
+#EXTINF:-1 tvg-id="917" tvg-name="" tvg-logo="http://static.epg.best/ca/Vision.ca.png" tvg-chno="331" channel-id="331",vision tv HD
 rtp://239.186.70.65:10000
-#EXTINF:-1 tvg-id="ComedyCentral.de" tvg-name="Comedy Central DE" tvg-logo="http://static.epg.best/de/ComedyCentral.de.png" tvg-chno="332" channel-id="332",Comedy Central
+#EXTINF:-1 tvg-id="ComedyCentral.de@SD" tvg-name="Comedy Central DE" tvg-logo="http://static.epg.best/de/ComedyCentral.de.png" tvg-chno="332" channel-id="332",Comedy Central
 rtp://239.186.64.61:10000
-#EXTINF:-1 tvg-id="Vox.de" tvg-name="VOX DE" tvg-logo="http://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="http://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
-#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="http://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="" tvg-logo="" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="WeltDerWunder.de" tvg-name="Welt der Wunder DE" tvg-logo="http://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV HD
+#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder DE" tvg-logo="http://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV HD
 rtp://239.186.68.198:10000
-#EXTINF:-1 tvg-id="Wetterfernsehen.de" tvg-name="Wetter.com TV DE" tvg-logo="http://static.epg.best/de/Wetterfernsehen.de.png" tvg-chno="338" channel-id="338",wetter.tv HD
+#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="Wetter.com TV DE" tvg-logo="http://static.epg.best/de/Wetterfernsehen.de.png" tvg-chno="338" channel-id="338",wetter.tv HD
 rtp://239.186.70.119:10000
-#EXTINF:-1 tvg-id="ZDF.de" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
 rtp://239.186.64.12:10000
-#EXTINF:-1 tvg-id="ZDF.de" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="http://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
 rtp://239.186.68.10:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
 rtp://239.186.64.118:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="http://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
 rtp://239.186.68.32:10000
-#EXTINF:-1 tvg-id="ZDFneo.de" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
 rtp://239.186.64.66:10000
-#EXTINF:-1 tvg-id="ZDFneo.de" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="http://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
 rtp://239.186.68.31:10000
-#EXTINF:-1 tvg-id="ZeeOne.de" tvg-name="Zee One DE" tvg-logo="http://static.epg.best/de/ZeeOne.de.png" tvg-chno="345" channel-id="345",ZEEONE HD
+#EXTINF:-1 tvg-id="1031" tvg-name="Zee One DE" tvg-logo="http://static.epg.best/de/ZeeOne.de.png" tvg-chno="345" channel-id="345",ZEEONE HD
 rtp://239.186.70.70:10000
 #EXTREM:italian
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="346" channel-id="346",7G Telecity
 rtp://239.186.74.23:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="347" channel-id="347",ALICE
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
 rtp://239.186.74.18:10000
-#EXTINF:-1 tvg-id="Boing.it" tvg-name="Boing IT" tvg-logo="http://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="http://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
 rtp://239.186.64.74:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Cartoonito.it" tvg-name="Cartoonito IT" tvg-logo="http://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",cartoonito
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="http://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",cartoonito
 rtp://239.186.66.176:10000
-#EXTINF:-1 tvg-id="Cielo.it" tvg-name="Cielo IT" tvg-logo="http://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="http://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
 rtp://239.186.64.76:10000
-#EXTINF:-1 tvg-id="CineSony.it" tvg-name="CineSony IT" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
+#EXTINF:-1 tvg-id="1381" tvg-name="CineSony IT" tvg-logo="http://static.epg.best/it/CineSony.it.png" tvg-chno="353" channel-id="353",CINE SONY
 rtp://239.186.74.22:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",Class TV Moda
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",Class TV Moda
 rtp://239.186.66.189:10000
-#EXTINF:-1 tvg-id="DMAX.it" tvg-name="DMAX IT" tvg-logo="http://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Discovery-italia DMAX
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="http://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Discovery-italia DMAX
 rtp://239.186.66.110:10000
-#EXTINF:-1 tvg-id="Frisbee.it" tvg-name="Frisbee IT" tvg-logo="http://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Discovery-italia Frisbee /FAMILY CLUB
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="http://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Discovery-italia Frisbee /FAMILY CLUB
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="Giallo.it" tvg-name="Giallo IT" tvg-logo="http://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Discovery-italia Giallo
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="http://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Discovery-italia Giallo
 rtp://239.186.66.187:10000
-#EXTINF:-1 tvg-id="K2.it" tvg-name="K2 IT" tvg-logo="http://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Discovery-italia K2 / FAMILY CLUB
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="http://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Discovery-italia K2 / FAMILY CLUB
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="" tvg-logo="" tvg-chno="359" channel-id="359",Discovery-italia MOTOR TREND
 rtp://239.186.74.21:10000
-#EXTINF:-1 tvg-id="NOVE.it" tvg-name="NOVE IT" tvg-logo="http://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Discovery-italia NOVE
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="http://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Discovery-italia NOVE
 rtp://239.186.64.158:10000
-#EXTINF:-1 tvg-id="RealTime.it" tvg-name="Real Time IT" tvg-logo="http://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Discovery-italia Real Time
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="http://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Discovery-italia Real Time
 rtp://239.186.66.43:10000
-#EXTINF:-1 tvg-id="Euronews.it" tvg-name="Euronews IT" tvg-logo="http://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="http://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it" tvg-name="Food Network IT" tvg-logo="http://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",food network I
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="http://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",food network I
 rtp://239.186.66.122:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="La7.it" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
 rtp://239.186.64.49:10000
-#EXTINF:-1 tvg-id="La7.it" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="http://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
 rtp://239.186.70.7:10000
-#EXTINF:-1 tvg-id="La7D.it" tvg-name="La7D IT" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
+#EXTINF:-1 tvg-id="LA7d.it@SD" tvg-name="La7D IT" tvg-logo="http://static.epg.best/it/La7D.it.png" tvg-chno="368" channel-id="368",LA7d
 rtp://239.186.64.164:10000
-#EXTINF:-1 tvg-id="MarcoPoloTV.de" tvg-name="Marco Polo TV DE" tvg-logo="http://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="369" channel-id="369",MARCOPOLO.TV
+#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo TV DE" tvg-logo="http://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="369" channel-id="369",MARCOPOLO.TV
 rtp://239.186.74.20:10000
-#EXTINF:-1 tvg-id="20Mediaset.it" tvg-name="20 Mediaset IT" tvg-logo="http://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",MEDIASET 20 HD
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="http://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",MEDIASET 20 HD
 rtp://239.186.70.152:10000
-#EXTINF:-1 tvg-id="Canale5.it" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
 rtp://239.186.64.46:10000
-#EXTINF:-1 tvg-id="Canale5.it" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="http://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
 rtp://239.186.68.163:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it" tvg-name="Mediaset Extra IT" tvg-logo="http://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="http://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
 rtp://239.186.66.37:10000
-#EXTINF:-1 tvg-id="FocusTv.it" tvg-name="Focus Tv IT" tvg-logo="http://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="http://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
 rtp://239.186.66.69:10000
-#EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
 rtp://239.186.64.48:10000
-#EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="http://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
 rtp://239.186.68.165:10000
-#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2 IT" tvg-logo="http://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="http://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
 rtp://239.186.66.44:10000
-#EXTINF:-1 tvg-id="Iris.it" tvg-name="Iris IT" tvg-logo="http://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="http://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
 rtp://239.186.64.75:10000
-#EXTINF:-1 tvg-id="La5.it" tvg-name="La5 IT" tvg-logo="http://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="http://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
 rtp://239.186.64.73:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="380" channel-id="380",MEDIASET Rete4
+#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="" tvg-logo="" tvg-chno="380" channel-id="380",MEDIASET Rete4
 rtp://239.186.64.47:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="" tvg-logo="" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
 rtp://239.186.64.214:10000
-#EXTINF:-1 tvg-id="TopCrime.it" tvg-name="Top Crime IT" tvg-logo="http://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="http://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
 rtp://239.186.66.180:10000
 #EXTINF:-1 tvg-id="ParamountChannel.it" tvg-name="Paramount Channel IT" tvg-logo="http://static.epg.best/it/ParamountChannel.it.png" tvg-chno="383" channel-id="383",Paramount Channel I
 rtp://239.186.64.122:10000
-#EXTINF:-1 tvg-id="RaiUno.it" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
 rtp://239.186.64.43:10000
-#EXTINF:-1 tvg-id="RaiUno.it" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="http://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
 rtp://239.186.68.36:10000
-#EXTINF:-1 tvg-id="RaiDue.it" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
 rtp://239.186.64.44:10000
-#EXTINF:-1 tvg-id="RaiDue.it" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="http://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
 rtp://239.186.70.77:10000
-#EXTINF:-1 tvg-id="RaiTre.it" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
 rtp://239.186.64.45:10000
-#EXTINF:-1 tvg-id="RaiTre.it" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="http://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
 rtp://239.186.70.78:10000
-#EXTINF:-1 tvg-id="Rai4.it" tvg-name="Rai 4 IT" tvg-logo="http://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="http://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
 rtp://239.186.64.50:10000
-#EXTINF:-1 tvg-id="Rai5.it" tvg-name="Rai 5 IT" tvg-logo="http://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="http://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiGulp.it" tvg-name="Rai Gulp IT" tvg-logo="http://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="http://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
 rtp://233.35.254.98:1234
-#EXTINF:-1 tvg-id="RaiMovie.it" tvg-name="Rai Movie IT" tvg-logo="http://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="http://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
 rtp://239.186.66.185:10000
-#EXTINF:-1 tvg-id="RaiNews.it" tvg-name="Rai News 24 IT" tvg-logo="http://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="http://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
 rtp://239.186.64.156:10000
-#EXTINF:-1 tvg-id="RaiPremium.it" tvg-name="Rai Premium IT" tvg-logo="http://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="http://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
 rtp://239.186.66.183:10000
-#EXTINF:-1 tvg-id="RaiScuola.it" tvg-name="Rai Scuola IT" tvg-logo="http://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="http://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
 rtp://239.186.66.34:10000
-#EXTINF:-1 tvg-id="RaiSportPlus.it" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport+
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport+
 rtp://239.186.64.157:10000
-#EXTINF:-1 tvg-id="RaiSportPlus.it" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport+ HD
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="http://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport+ HD
 rtp://239.186.70.2:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="399" channel-id="399",Rai Sport
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="" tvg-logo="" tvg-chno="399" channel-id="399",Rai Sport
 rtp://239.186.64.159:10000
-#EXTINF:-1 tvg-id="RaiStoria.it" tvg-name="Rai Storia IT" tvg-logo="http://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="http://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
 rtp://239.186.64.162:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it" tvg-name="Rai Yoyo IT" tvg-logo="http://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="http://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="RSILA1.ch" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
-#EXTINF:-1 tvg-id="RSILA1.ch" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="http://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 HD
 rtp://239.186.68.5:10000
-#EXTINF:-1 tvg-id="RSILA2.ch" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
-#EXTINF:-1 tvg-id="RSILA2.ch" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 HD
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="http://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 HD
 rtp://239.186.68.6:10000
-#EXTINF:-1 tvg-id="SkyTG24.it" tvg-name="Sky TG24 IT" tvg-logo="http://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="http://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
 rtp://239.186.66.177:10000
-#EXTINF:-1 tvg-id="SpikeTV.it" tvg-name="SpikeTV IT" tvg-logo="http://static.epg.best/it/SpikeTV.it.png" tvg-chno="407" channel-id="407",Spike
+#EXTINF:-1 tvg-id="1347" tvg-name="SpikeTV IT" tvg-logo="http://static.epg.best/it/SpikeTV.it.png" tvg-chno="407" channel-id="407",Spike
 rtp://239.186.66.178:10000
-#EXTINF:-1 tvg-id="Sportitalia.it" tvg-name="Sportitalia IT" tvg-logo="http://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport Italia SI
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="http://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport Italia SI
 rtp://239.186.74.24:10000
-#EXTINF:-1 tvg-id="super.it" tvg-name="super! IT" tvg-logo="" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="super! IT" tvg-logo="" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="SuperTennis.it" tvg-name="SuperTennis IT" tvg-logo="http://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SUPER TENNIS HD
+#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis IT" tvg-logo="http://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SUPER TENNIS HD
 rtp://239.186.70.154:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="410" channel-id="410",teleticino
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="" tvg-logo="" tvg-chno="410" channel-id="410",teleticino
 rtp://239.186.64.99:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="411" channel-id="411",teleticino HD
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="" tvg-logo="" tvg-chno="411" channel-id="411",teleticino HD
 rtp://239.186.68.201:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
 rtp://239.186.64.154:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
 rtp://239.186.64.152:10000
-#EXTINF:-1 tvg-id="TV8.it" tvg-name="TV8 IT" tvg-logo="http://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="http://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
 rtp://239.186.64.161:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="VH1.it" tvg-name="VH1 IT" tvg-logo="http://static.epg.best/it/VH1.it.png" tvg-chno="418" channel-id="418",VH1 Italia
+#EXTINF:-1 tvg-id="645" tvg-name="VH1 IT" tvg-logo="http://static.epg.best/it/VH1.it.png" tvg-chno="418" channel-id="418",VH1 Italia
 rtp://239.186.66.240:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="415" channel-id="415",TV2000
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="" tvg-logo="" tvg-chno="415" channel-id="415",TV2000
 rtp://239.186.66.108:10000
 #EXTREM:others
-#EXTINF:-1 tvg-id="2MMonde.ma" tvg-name="2M Monde MA" tvg-logo="http://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="http://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="420" channel-id="420",360
+#EXTINF:-1 tvg-id="360.tr@SD" tvg-name="" tvg-logo="" tvg-chno="420" channel-id="420",360
 rtp://239.186.64.204:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv avrupa
+#EXTINF:-1 tvg-id="ATVAvrupa.tr@SD" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv avrupa
 rtp://239.186.64.201:10000
-#EXTINF:-1 tvg-id="24Horas.es" tvg-name="24 Horas ES" tvg-logo="http://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="http://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
 rtp://239.186.64.196:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="423" channel-id="423",Canal Extremadura
 rtp://239.186.64.222:10000
-#EXTINF:-1 tvg-id="EuroD.nl" tvg-name="Euro D NL" tvg-logo="http://static.epg.best/nl/EuroD.nl.png" tvg-chno="424" channel-id="424",EURO D
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D NL" tvg-logo="http://static.epg.best/nl/EuroD.nl.png" tvg-chno="424" channel-id="424",EURO D
 rtp://239.186.64.199:10000
-#EXTINF:-1 tvg-id="Eurostar.nl" tvg-name="Eurostar NL" tvg-logo="http://static.epg.best/nl/Eurostar.nl.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar NL" tvg-logo="http://static.epg.best/nl/Eurostar.nl.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="Powerturk.tr" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
+#EXTINF:-1 tvg-id="320" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="426" channel-id="426",POWERTURK
 rtp://239.186.66.134:10000
-#EXTINF:-1 tvg-id="Powerturk.tr" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
+#EXTINF:-1 tvg-id="320" tvg-name="Powerturk TR" tvg-logo="http://static.epg.best/tr/Powerturk.tr.png" tvg-chno="427" channel-id="427",POWERTURK HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="Showmax.tr" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
-#EXTINF:-1 tvg-id="Showmax.tr" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="http://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW
 rtp://239.186.64.200:10000
-#EXTINF:-1 tvg-id="ShowTV.tr" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="http://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW HD
 rtp://239.186.84.36:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr" tvg-name="TRT Turk TR" tvg-logo="http://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="http://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
 #EXTINF:-1 tvg-id="TVNET.tr" tvg-name="TVNET TR" tvg-logo="http://static.epg.best/tr/TVNET.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
 rtp://239.186.64.205:10000
-#EXTINF:-1 tvg-id="Alarabiya.sa" tvg-name="Al Arabiya SA" tvg-logo="http://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="http://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
 rtp://239.186.64.192:10000
-#EXTINF:-1 tvg-id="B1.ro" tvg-name="B1 RO" tvg-logo="http://static.epg.best/ro/B1.ro.png" tvg-chno="433" channel-id="433",b1
+#EXTINF:-1 tvg-id="AB1.fr@SD" tvg-name="B1 RO" tvg-logo="http://static.epg.best/ro/B1.ro.png" tvg-chno="433" channel-id="433",b1
 rtp://239.186.66.111:10000
-#EXTINF:-1 tvg-id="BVN.nl" tvg-name="BVN NL" tvg-logo="http://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="http://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
 rtp://239.186.64.195:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="http://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
 rtp://239.186.70.89:10000
-#EXTINF:-1 tvg-id="Channel1.il" tvg-name="Channel 1 IL" tvg-logo="http://static.epg.best/il/Channel1.il.png" tvg-chno="437" channel-id="437",Channel1 RU
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 1 IL" tvg-logo="http://static.epg.best/il/Channel1.il.png" tvg-chno="437" channel-id="437",Channel1 RU
 rtp://239.186.64.82:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="438" channel-id="438",CTC International
+#EXTINF:-1 tvg-id="409" tvg-name="" tvg-logo="" tvg-chno="438" channel-id="438",CTC International
 rtp://239.186.66.117:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae" tvg-name="Dubai TV AE" tvg-logo="http://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="http://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI
 rtp://239.186.66.119:10000
-#EXTINF:-1 tvg-id="DunaTV.hu" tvg-name="Duna TV HU" tvg-logo="http://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="http://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
 rtp://239.186.66.120:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu" tvg-name="Duna World HU" tvg-logo="http://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="http://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
 rtp://239.186.66.85:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="443" channel-id="443",ESC1 (Al Masriya)
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.ca" tvg-name="ERT World CA" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World CA" tvg-logo="http://static.epg.best/ca/ERTWorld.ca.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="446" channel-id="446",HRT1
+#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="" tvg-logo="" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="http://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN TV
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN TV
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="449" channel-id="449",KURDISTAN TV HD
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="449" channel-id="449",KURDISTAN TV HD
 rtp://239.186.70.129:10000
-#EXTINF:-1 tvg-id="KuriakosTv.pt" tvg-name="Kuriakos Tv PT" tvg-logo="http://static.epg.best/pt/KuriakosTv.pt.png" tvg-chno="450" channel-id="450",KURIAKOS TV HD
+#EXTINF:-1 tvg-id="1401" tvg-name="Kuriakos Tv PT" tvg-logo="http://static.epg.best/pt/KuriakosTv.pt.png" tvg-chno="450" channel-id="450",KURIAKOS TV HD
 rtp://239.186.70.149:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
 rtp://239.186.66.132:10000
 #EXTINF:-1 tvg-id="PlanetTurk.tr" tvg-name="Planet Türk TR" tvg-logo="http://static.epg.best/tr/PlanetTurk.tr.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="453" channel-id="453",PTC CBET HD
 rtp://239.186.70.164:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="454" channel-id="454",PTPC www.rtrs.tv
+#EXTINF:-1 tvg-id="324" tvg-name="" tvg-logo="" tvg-chno="454" channel-id="454",PTPC www.rtrs.tv
 rtp://239.186.66.136:10000
-#EXTINF:-1 tvg-id="ProTV.ro" tvg-name="Pro TV RO" tvg-logo="http://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="http://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="http://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK.al" tvg-name="RTK AL" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="http://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",RUDAW HD
+#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",RUDAW HD
 rtp://239.186.68.247:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="602" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr" tvg-name="TRT Kurdî TR" tvg-logo="http://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="http://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
 rtp://239.186.66.204:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl" tvg-name="TVP Polonia PL" tvg-logo="http://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="http://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="" tvg-logo="" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="466" channel-id="466",Z1
 rtp://239.186.66.149:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia TV
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia TV
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="TVGalicia.es" tvg-name="TV Galicia ES" tvg-logo="http://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="http://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
 rtp://239.186.64.187:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="469" channel-id="469",tve international
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="" tvg-logo="" tvg-chno="469" channel-id="469",tve international
 rtp://239.186.64.54:10000
-#EXTINF:-1 tvg-id="RecordTV.br" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record Int. EU
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record Int. EU
 rtp://239.186.64.83:10000
-#EXTINF:-1 tvg-id="RecordTV.br" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record Int. EU HD
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="http://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record Int. EU HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional PT" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="http://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
 rtp://239.186.64.77:10000

--- a/swisscom-hd.m3u
+++ b/swisscom-hd.m3u
@@ -107,7 +107,7 @@ rtp://239.186.68.135:10000
 rtp://239.186.68.132:10000
 #EXTINF:-1 tvg-id="tvmonaco.fr" tvg-name="tvmonaco FR" tvg-logo="https://static.epg.best/fr/tvmonaco.fr.png" tvg-chno="" channel-id="",TV Monaco HD
 rtp://239.186.68.167:10000
-#EXTINF:-1 tvg-id="" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
+#EXTINF:-1 tvg-id="t18.fr" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
 rtp://239.186.70.24:10000
 #EXTINF:-1 tvg-id="canalbfr.ch" tvg-name="canalbfr CH" tvg-logo="https://static.epg.best/ch/canalbfr.ch.png" tvg-chno="" channel-id="",Canalb fr HD
 rtp://239.186.70.174:10000
@@ -120,13 +120,13 @@ rtp://239.186.68.43:10000
 rtp://239.186.68.41:10000
 #EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="https://static.epg.best/uk/CBBC.uk.png" tvg-chno="92" channel-id="92",BBC THREE HD / CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="BBCFour.uk@UK" tvg-name="BBC Four" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
 #EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="https://static.epg.best/uk/CBeebies.uk.png" tvg-chno="94" channel-id="94",BBC CBeebies HD / BBC FOUR HD
 rtp://239.186.68.152:10000
 #EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (UK) HD
 rtp://239.186.68.160:10000
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-name="BBC World News" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
 rtp://239.186.68.214:10000
 #EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament" tvg-logo="https://static.epg.best/uk/BBCParliament.uk.png" tvg-chno="97" channel-id="97",BBC PARLIAMENT HD
 rtp://239.186.70.65:10000
@@ -142,7 +142,7 @@ rtp://239.186.66.116:10000
 rtp://239.186.70.224:10000
 #EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN" tvg-logo="https://static.epg.best/uk/CNN.uk.png" tvg-chno="107" channel-id="107",CNN International HD
 rtp://239.186.70.23:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
+#EXTINF:-1 tvg-id="UandDrama.uk" tvg-name="Drama" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
 rtp://239.186.66.140:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="109" channel-id="109",DW English HD
 rtp://239.186.70.249:10000
@@ -180,7 +180,7 @@ rtp://239.186.66.242:10000
 rtp://239.186.66.243:10000
 #EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English" tvg-logo="https://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",ALJAZEERA E HD
 rtp://239.186.68.171:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
+#EXTINF:-1 tvg-id="Dave.uk" tvg-name="Dave" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
 rtp://239.186.66.253:10000
 #EXTINF:-1 tvg-id="Quest.uk@SD" tvg-name="Quest" tvg-logo="https://static.epg.best/uk/quest.uk.png" tvg-chno="122" channel-id="122",Quest HD
 rtp://@239.186.84.2:10000
@@ -194,11 +194,11 @@ rtp://239.186.74.88:10000
 rtp://239.186.74.84:10000
 #EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="https://static.epg.best/uk/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
 rtp://239.186.74.74:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="UandYesterday.uk" tvg-name="Yesterday" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
 #EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
+#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Pick" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
 rtp://239.186.84.95:10000
 #EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
@@ -245,7 +245,7 @@ rtp://239.186.68.195:10000
 rtp://239.186.70.116:10000
 #EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ / Nickelodeon" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="239" channel-id="239",7+ HD / Nick D CH HD
 rtp://239.186.68.175:10000
-#EXTINF:-1 tvg-id="" tvg-name="ALF-TV" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
+#EXTINF:-1 tvg-id="Alf-TV.ch" tvg-name="ALF-TV" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
 rtp://239.186.70.179:10000
 #EXTINF:-1 tvg-id="AW1.de" tvg-name="AW1 DE" tvg-logo="https://static.epg.best/de/AW1.de.png" tvg-chno="180" channel-id="180",aw1 tv HD
 rtp://239.186.70.9:10000
@@ -303,7 +303,7 @@ rtp://239.186.68.28:10000
 rtp://239.186.84.137:10000
 #EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY CH HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
 #EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="https://static.epg.best/at/melodietv.at.png" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
@@ -311,7 +311,7 @@ rtp://239.186.74.15:10000
 rtp://239.186.68.207:10000
 #EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
 #EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="Nitro" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
@@ -331,7 +331,7 @@ rtp://239.186.70.87:10000
 rtp://239.186.68.191:10000
 #EXTINF:-1 tvg-id="r-9.at" tvg-name="R-9 AT" tvg-logo="https://static.epg.best/at/r-9.at.png" tvg-chno="255" channel-id="255",R9 Oesterreich HD
 rtp://239.186.68.248:10000
-#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
+#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
 rtp://239.186.68.157:10000
 #EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="regioTVplus" tvg-logo="https://static.epg.best/de/RegioTVplus.ch.png" tvg-chno="258" channel-id="258",regioTVplus HD
 rtp://239.186.70.40:10000
@@ -339,9 +339,9 @@ rtp://239.186.70.40:10000
 rtp://239.186.70.202:10000
 #EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
+#EXTINF:-1 tvg-id="RTLZwei.de@SD" tvg-name="RTL ZWEI" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTL Plus DE" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
+#EXTINF:-1 tvg-id="RTLup.de@SD" tvg-name="RTLup" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
 #EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1" tvg-logo="https://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
@@ -409,7 +409,7 @@ rtp://239.186.70.20:10000
 rtp://239.186.70.4:10000
 #EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
 #EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
@@ -429,7 +429,7 @@ rtp://239.186.74.70:10000
 rtp://@239.186.84.17:10000
 #EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="Schlager Deluxe" tvg-logo="https://static.epg.best/de/SchlagerDeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
 rtp://239.186.74.105:10000
-#EXTINF:-1 tvg-id="" tvg-name="Schlager Paradies DE" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
+#EXTINF:-1 tvg-id="SchlagerParadies.de" tvg-name="Schlagerparadies TV" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
 rtp://239.186.84.37:10000
 #EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="Volksmusik.TV" tvg-logo="https://static.epg.best/de/Volksmusik.de.png" tvg-chno="" channel-id="",Volksmusik.tv HD
 rtp://239.186.70.97:10000
@@ -512,7 +512,7 @@ rtp://239.186.84.91:10000
 rtp://239.186.66.186:10000
 #EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros. Discovery Frisbee
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
+#EXTINF:-1 tvg-id="HGTV.it@SD" tvg-name="Home & Garden TV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
 rtp://239.186.84.101:10000
 #EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
@@ -637,7 +637,7 @@ rtp://239.186.70.169:10000
 #EXTREM:portuguese
 #EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP mundo_.
+#EXTINF:-1 tvg-id="RTPMundo.pt@SD" tvg-name="RTP Mundo" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Mundo
 rtp://239.186.64.77:10000
 #EXTREM:spanish
 #EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragón TV Int" tvg-logo="https://static.epg.best/es/aragonint.es.png" tvg-chno="143" channel-id="143",Aragon int
@@ -667,7 +667,7 @@ rtp://239.186.84.24:10000
 rtp://239.186.68.226:10000
 #EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
 rtp://239.186.84.36:10000
-#EXTINF:-1 tvg-id="" tvg-name="TGRT EU" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="TGRTEU.tr" tvg-name="TGRT EU" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
 #EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT Turk HD
 rtp://239.186.70.210:10000
@@ -698,11 +698,11 @@ rtp://239.186.70.207:10000
 rtp://239.186.70.209:10000
 #EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA HD
 rtp://239.186.84.96:10000
-#EXTINF:-1 tvg-id="" tvg-name="TVP info PL" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
+#EXTINF:-1 tvg-id="TVPinfo.pl" tvg-name="TVP Info" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
 rtp://239.186.84.151:10000
-#EXTINF:-1 tvg-id="" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
+#EXTINF:-1 tvg-id="EpicDrama.pl" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
 rtp://239.186.70.99:10000
-#EXTINF:-1 tvg-id="" ,YKPAÏHA 24 / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="" tvg-name="FreeDOM",YKPAÏHA 24 / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 tvg-id="EspresoTV.ua@SD",Espreso TV HD (ukr)
 rtp://239.186.84.176:10000
@@ -724,7 +724,7 @@ rtp://239.186.70.80:10000
 rtp://239.186.70.183:10000
 #EXTINF:-1 tvg-id="HRTInternational.hr@SD" tvg-name="HRT Int." tvg-logo="https://static.epg.best/hr/HRTint.hr" tvg-chno="446" channel-id="446",HRT int HD
 rtp://239.186.70.153:10000
-#EXTINF:-1 tvg-id="" tvg-name="HRT4 HR" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
+#EXTINF:-1 tvg-id="HRT4.hr" tvg-name="HRT 4" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
 rtp://239.186.84.145:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="https://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000

--- a/swisscom-hd.m3u
+++ b/swisscom-hd.m3u
@@ -1,459 +1,459 @@
 #EXTM3U 
 #PLAYLIST: blue tv open channels
 #EXTREM:french
-#EXTINF:-1 tvg-id="C202.api.telerama.fr" tvg-name="RTS Un" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="1" channel-id="1",RTS1 FHD
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="1" channel-id="1",RTS1 FHD
 rtp://239.186.76.26:10000
-#EXTINF:-1 tvg-id="C183.api.telerama.fr" tvg-name="RTS Deux" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="2" channel-id="2",RTS2 FHD
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="2" channel-id="2",RTS2 FHD
 rtp://239.186.76.27:10000
-#EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="3" channel-id="3",TF1 CH HD
+#EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="3" channel-id="3",TF1 CH HD
 rtp://239.186.68.21:10000
-#EXTINF:-1 tvg-id="C4.api.telerama.fr" tvg-name="France 2" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="4" channel-id="4",France2 HD
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="4" channel-id="4",France2 HD
 rtp://239.186.68.19:10000
-#EXTINF:-1 tvg-id="C80.api.telerama.fr" tvg-name="France 3" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="5" channel-id="5",France3 HD
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="5" channel-id="5",France3 HD
 rtp://239.186.70.25:10000
-#EXTINF:-1 tvg-id="C78.api.telerama.fr" tvg-name="France 4" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="6" channel-id="6",France4 HD
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="6" channel-id="6",France4 HD
 rtp://239.186.84.55:10000
-#EXTINF:-1 tvg-id="C47.api.telerama.fr" tvg-name="France 5" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="7" channel-id="7",France5 HD
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="7" channel-id="7",France5 HD
 rtp://239.186.70.27:10000
-#EXTINF:-1 tvg-id="C118.api.telerama.fr" tvg-name="M6" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="8" channel-id="8",M6 CH HD
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="8" channel-id="8",M6 CH HD
 rtp://239.186.68.20:10000
-#EXTINF:-1 tvg-id="C111.api.telerama.fr" tvg-name="Arte" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="9" channel-id="9",arte F HD
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="9" channel-id="9",arte F HD
 rtp://239.186.68.18:10000
-#EXTINF:-1 tvg-id="C119.api.telerama.fr" tvg-name="W9" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="11" channel-id="11",W9 CH HD
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="11" channel-id="11",W9 CH HD
 rtp://239.186.70.38:10000
-#EXTINF:-1 tvg-id="C195.api.telerama.fr" tvg-name="TMC" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="12" channel-id="12",TMC CH HD
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="12" channel-id="12",TMC CH HD
 rtp://239.186.70.37:10000
-#EXTINF:-1 tvg-id="C446.api.telerama.fr" tvg-name="TFX" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="13" channel-id="13",TFX CH HD
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="13" channel-id="13",TFX CH HD
 rtp://239.186.70.34:10000
-#EXTINF:-1 tvg-id="C234.api.telerama.fr" tvg-name="LCP Public Sénat" tvg-logo="https://static.epg.best/fr/LaChaineParlementaire.fr.png" tvg-chno="15" channel-id="15",LCP8 Public Sénat HD
+#EXTINF:-1 tvg-id="LCP.fr@SD" tvg-name="LCP Public Sénat" tvg-logo="https://static.epg.best/fr/LaChaineParlementaire.fr.png" tvg-chno="15" channel-id="15",LCP8 Public Sénat HD
 rtp://239.186.84.35:10000
-#EXTINF:-1 tvg-id="C2111.api.telerama.fr" tvg-name="franceinfo:" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="29" channel-id="29",franceinfo HD
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo:" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="29" channel-id="29",franceinfo HD
 rtp://239.186.70.121:10000
-#EXTINF:-1 tvg-id="C481.api.telerama.fr" tvg-name="BFM TV" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="17" channel-id="17",BFMTV CH HD
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="17" channel-id="17",BFMTV CH HD
 rtp://239.186.68.196:10000
-#EXTINF:-1 tvg-id="C226.api.telerama.fr" tvg-name="CNews" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="18" channel-id="18",CNEWS HD
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="18" channel-id="18",CNEWS HD
 rtp://239.186.70.30:10000
-#EXTINF:-1 tvg-id="C482.api.telerama.fr" tvg-name="Gulli" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="20" channel-id="20",gulli HD
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="20" channel-id="20",gulli HD
 rtp://239.186.70.29:10000
-#EXTINF:-1 tvg-id="C1403.api.telerama.fr" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="24" channel-id="24",6ter HD
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="24" channel-id="24",6ter HD
 rtp://239.186.68.134:10000
-#EXTINF:-1 tvg-id="C112.api.telerama.fr" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
+#EXTINF:-1 tvg-id="LCI.fr@SD" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
 rtp://239.186.68.241:10000
-#EXTINF:-1 tvg-id="C205.api.telerama.fr" tvg-name="TV5MONDE France Belgique Suisse Monaco" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5MONDE France Belgique Suisse Monaco" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
 rtp://239.186.70.41:10000
-#EXTINF:-1 tvg-id="C232.api.telerama.fr" tvg-name="TV5MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="31" channel-id="31",TV5 MONDE EUROPE HD
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="31" channel-id="31",TV5 MONDE EUROPE HD
 rtp://239.186.84.54:10000
-#EXTINF:-1 tvg-id="C110.api.telerama.fr" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="32" channel-id="32",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="32" channel-id="32",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="C421.api.telerama.fr" tvg-name="8 Mont-Blanc" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="75" channel-id="75",8 Mont-Blanc HD
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="75" channel-id="75",8 Mont-Blanc HD
 rtp://239.186.70.106:10000
-#EXTINF:-1 tvg-id="Canal9.ch" tvg-name="Canal9.ch" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="77" channel-id="77",Canal9 HD
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal9.ch" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="77" channel-id="77",Canal9 HD
 rtp://239.186.68.144:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="78" channel-id="78",CanalAlpha JU HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="78" channel-id="78",CanalAlpha JU HD
 rtp://239.186.68.193:10000
-#EXTINF:-1 tvg-id="CanalAlphaNE.ch" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="79" channel-id="79",Canal Alpha NE HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="79" channel-id="79",Canal Alpha NE HD
 rtp://239.186.68.194:10000
-#EXTINF:-1 tvg-id="C140.api.telerama.fr" tvg-name="Euronews" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="80" channel-id="80",euronews. F HD
+#EXTINF:-1 tvg-id="EuronewsFrench.fr@SD" tvg-name="Euronews" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="80" channel-id="80",euronews. F HD
 rtp://239.186.70.148:10000
-#EXTINF:-1 tvg-id="C529.api.telerama.fr" tvg-name="France 24" tvg-logo="https://static.epg.best/fr/France24f.fr.png" tvg-chno="63" channel-id="63",France24 HD
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="https://static.epg.best/fr/France24f.fr.png" tvg-chno="63" channel-id="63",France24 HD
 rtp://239.186.70.125:10000
-#EXTINF:-1 tvg-id="C781.api.telerama.fr" tvg-name="" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
+#EXTINF:-1 tvg-id="i24NEWSFrench.il@SD" tvg-name="" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
 #EXTINF:-1 tvg-id="icitv.ch" tvg-name="icitv CH" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
 rtp://239.186.70.133:10000
-#EXTINF:-1 tvg-id="latele.ch" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
-#EXTINF:-1 tvg-id="telebielingue.ch" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="303" channel-id="303",TeleBielingue HD
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="303" channel-id="303",TeleBielingue HD
 rtp://239.186.70.82:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",leman bleu HD
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",leman bleu HD
 rtp://239.186.70.39:10000
-#EXTINF:-1 tvg-id="carac1.ch" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="84" channel-id="84",carac1 HD (ex rouge TV HD)
+#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="84" channel-id="84",carac1 HD (ex rouge TV HD)
 rtp://239.186.68.253:10000
-#EXTINF:-1 tvg-id="carac2.ch" tvg-name="carac2 CH" tvg-logo="https://static.epg.best/ch/carac2.ch.png" tvg-chno="83" channel-id="83",carac2 HD (ex one tv HD)
+#EXTINF:-1 tvg-id="OneTV.ch@SD" tvg-name="carac2 CH" tvg-logo="https://static.epg.best/ch/carac2.ch.png" tvg-chno="83" channel-id="83",carac2 HD (ex one tv HD)
 rtp://239.186.70.12:10000
-#EXTINF:-1 tvg-id="carac3.ch" tvg-name="carac3 CH" tvg-logo="https://static.epg.best/ch/carac3.ch.png" tvg-chno="77" channel-id="77",carac3 HD (ex lfm TV HD)
+#EXTINF:-1 tvg-id="LFMTV.ch@SD" tvg-name="carac3 CH" tvg-logo="https://static.epg.best/ch/carac3.ch.png" tvg-chno="77" channel-id="77",carac3 HD (ex lfm TV HD)
 rtp://239.186.70.11:10000
-#EXTINF:-1 tvg-id="carac4.ch" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="79" channel-id="79",carac4 HD (ex TV SUISSE PLUS HD)
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="79" channel-id="79",carac4 HD (ex TV SUISSE PLUS HD)
 rtp://239.186.70.104:10000
-#EXTINF:-1 tvg-id="carac5.ch" tvg-name="carac5 CH" tvg-logo="https://static.epg.best/ch/teleswizz.ch.png" tvg-chno="74" channel-id="74",carac5 HD (ex TeleSwizz HD)
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac5 CH" tvg-logo="https://static.epg.best/ch/teleswizz.ch.png" tvg-chno="74" channel-id="74",carac5 HD (ex TeleSwizz HD)
 rtp://239.186.68.208:10000
-#EXTINF:-1 tvg-id="tvm3.ch" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/tvm3.ch.png" tvg-chno="80" channel-id="80",tvm3 HD
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/tvm3.ch.png" tvg-chno="80" channel-id="80",tvm3 HD
 rtp://239.186.70.21:10000
-#EXTINF:-1 tvg-id="MaxTV.ch" tvg-name="MaxTV CH" tvg-logo="https://static.epg.best/ch/maxtv.ch.png" tvg-chno="81" channel-id="81",maxtv HD/DieuTV HD
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="MaxTV CH" tvg-logo="https://static.epg.best/ch/maxtv.ch.png" tvg-chno="81" channel-id="81",maxtv HD/DieuTV HD
 rtp://239.186.68.199:10000
-#EXTINF:-1 tvg-id="NRTV.ch" tvg-name="NRTV CH" tvg-logo="https://static.epg.best/ch/nrtv.ch.png" tvg-chno="82" channel-id="82",nrtv HD
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV CH" tvg-logo="https://static.epg.best/ch/nrtv.ch.png" tvg-chno="82" channel-id="82",nrtv HD
 rtp://239.186.70.66:10000
-#EXTINF:-1 tvg-id="grtv.ch" tvg-name="GRTV CH" tvg-logo="https://static.epg.best/ch/grtv.ch.png" tvg-chno="85" channel-id="85",GRTV / TéléVersoix HD
+#EXTINF:-1 tvg-id="371" tvg-name="GRTV CH" tvg-logo="https://static.epg.best/ch/grtv.ch.png" tvg-chno="85" channel-id="85",GRTV / TéléVersoix HD
 rtp://239.186.70.155:10000
-#EXTINF:-1 tvg-id="TVOnex.ch" tvg-name="TV Onex CH" tvg-logo="https://static.epg.best/ch/tvonex.ch.png" tvg-chno="86" channel-id="86",TV Onex HD
+#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="TV Onex CH" tvg-logo="https://static.epg.best/ch/tvonex.ch.png" tvg-chno="86" channel-id="86",TV Onex HD
 rtp://239.186.70.132:10000
 #EXTINF:-1 ,Rhone TV HD
 rtp://239.186.84.172:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="89" channel-id="89",blue ZOOM F HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="89" channel-id="89",blue ZOOM F HD
 rtp://239.186.68.244:10000
 #EXTINF:-1 tvg-id="SRTB.bj" tvg-name="SRTB BJ" tvg-logo="https://static.epg.best/bj/SRTB.bj.png" tvg-chno="90" channel-id="90",SRTB BENIN TV
 rtp://239.186.74.97:10000
-#EXTINF:-1 tvg-id="C1404.api.telerama.fr" tvg-name="TF1 Séries Films FR" tvg-logo="https://static.epg.best/fr/TF1SeriesFilms.fr.png" tvg-chno="25" channel-id="25",TF1 Series Films HD
+#EXTINF:-1 tvg-id="TF1SeriesFilms.fr@SD" tvg-name="TF1 Séries Films FR" tvg-logo="https://static.epg.best/fr/TF1SeriesFilms.fr.png" tvg-chno="25" channel-id="25",TF1 Series Films HD
 rtp://239.186.68.133:10000
-#EXTINF:-1 tvg-id="C1399.api.telerama.fr" tvg-name="RMC Life FR" tvg-logo="https://static.epg.best/fr/rmclife.fr.png" tvg-chno="27" channel-id="27",RMC Life HD
+#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Life FR" tvg-logo="https://static.epg.best/fr/rmclife.fr.png" tvg-chno="27" channel-id="27",RMC Life HD
 rtp://239.186.68.131:10000
-#EXTINF:-1 tvg-id="C254.api.telerama.fr" tvg-name="AB3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="35" channel-id="35",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="35" channel-id="35",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="C1400.api.telerama.fr" tvg-name="RMC Découverte FR" tvg-logo="https://static.epg.best/fr/RMCdecouverte.fr.png" tvg-chno="26" channel-id="26",RMC Decouvertes HD
+#EXTINF:-1 tvg-id="RMCDecouverte.fr@SD" tvg-name="RMC Découverte FR" tvg-logo="https://static.epg.best/fr/RMCdecouverte.fr.png" tvg-chno="26" channel-id="26",RMC Decouvertes HD
 rtp://239.186.68.130:10000
-#EXTINF:-1 tvg-id="C1402.api.telerama.fr" tvg-name="RMC Story FR" tvg-logo="https://static.epg.best/fr/RMCStory.fr.png" tvg-chno="22" channel-id="22",RMC Story HD
+#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Story FR" tvg-logo="https://static.epg.best/fr/RMCStory.fr.png" tvg-chno="22" channel-id="22",RMC Story HD
 rtp://239.186.68.135:10000
-#EXTINF:-1 tvg-id="C1401.api.telerama.fr" tvg-name="LEquipe21" tvg-logo="https://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="23" channel-id="23",La chaine L'EQUIPE HD
+#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="LEquipe21" tvg-logo="https://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="23" channel-id="23",La chaine L'EQUIPE HD
 rtp://239.186.68.132:10000
 #EXTINF:-1 tvg-id="tvmonaco.fr" tvg-name="tvmonaco FR" tvg-logo="https://static.epg.best/fr/tvmonaco.fr.png" tvg-chno="" channel-id="",TV Monaco HD
 rtp://239.186.68.167:10000
-#EXTINF:-1 tvg-id="t18.fr" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
+#EXTINF:-1 tvg-id="495" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
 rtp://239.186.70.24:10000
 #EXTINF:-1 tvg-id="canalbfr.ch" tvg-name="canalbfr CH" tvg-logo="https://static.epg.best/ch/canalbfr.ch.png" tvg-chno="" channel-id="",Canalb fr HD
 rtp://239.186.70.174:10000
 #EXTINF:-1 tvg-id="novo19.fr" tvg-name="NOVO19 FR" tvg-logo="https://static.epg.best/fr/novo19.fr.png" tvg-chno="" channel-id="",NOVO19 HD
 rtp://239.186.70.167:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="C16.api.telerama.fr" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/uk/BBC1.uk.png" tvg-chno="90" channel-id="90",BBC ONE HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/uk/BBC1.uk.png" tvg-chno="90" channel-id="90",BBC ONE HD
 rtp://239.186.68.43:10000
-#EXTINF:-1 tvg-id="C17.api.telerama.fr" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/uk/BBC2.uk.png" tvg-chno="91" channel-id="91",BBC TWO HD
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/uk/BBC2.uk.png" tvg-chno="91" channel-id="91",BBC TWO HD
 rtp://239.186.68.41:10000
-#EXTINF:-1 tvg-id="CBBC.uk" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/uk/CBBC.uk.png" tvg-chno="92" channel-id="92",BBC THREE HD / CBBC HD
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/uk/CBBC.uk.png" tvg-chno="92" channel-id="92",BBC THREE HD / CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="BBC4.uk" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
-#EXTINF:-1 tvg-id="CBeebies.uk" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/uk/CBeebies.uk.png" tvg-chno="94" channel-id="94",BBC CBeebies HD / BBC FOUR HD
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/uk/CBeebies.uk.png" tvg-chno="94" channel-id="94",BBC CBeebies HD / BBC FOUR HD
 rtp://239.186.68.152:10000
-#EXTINF:-1 tvg-id="C16.api.telerama.fr" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (UK) HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (UK) HD
 rtp://239.186.68.160:10000
-#EXTINF:-1 tvg-id="C16.api.telerama.fr" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
 rtp://239.186.68.214:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk" tvg-name="BBC Parliament UK" tvg-logo="https://static.epg.best/uk/BBCParliament.uk.png" tvg-chno="97" channel-id="97",BBC PARLIAMENT HD
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament UK" tvg-logo="https://static.epg.best/uk/BBCParliament.uk.png" tvg-chno="97" channel-id="97",BBC PARLIAMENT HD
 rtp://239.186.70.65:10000
-#EXTINF:-1 tvg-id="BloombergTV.uk" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="98" channel-id="98",Bloomberg TV UK HD
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="98" channel-id="98",Bloomberg TV UK HD
 rtp://239.186.68.125:10000
-#EXTINF:-1 tvg-id="CGTN.au" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="100" channel-id="100",CGTN E HD
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="100" channel-id="100",CGTN E HD
 rtp://239.186.70.90:10000
-#EXTINF:-1 tvg-id="Channel4.uk" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/uk/Channel4.uk.png" tvg-chno="101" channel-id="101",Channel4 HD
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/uk/Channel4.uk.png" tvg-chno="101" channel-id="101",Channel4 HD
 rtp://239.186.68.40:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="104" channel-id="104",Clubland TV
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="104" channel-id="104",Clubland TV
 rtp://239.186.66.116:10000
-#EXTINF:-1 tvg-id="CNBC.uk" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/uk/CNBC.uk.png" tvg-chno="105" channel-id="105",CNBC UK HD
+#EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/uk/CNBC.uk.png" tvg-chno="105" channel-id="105",CNBC UK HD
 rtp://239.186.70.224:10000
-#EXTINF:-1 tvg-id="CNN.uk" tvg-name="CNN UK" tvg-logo="https://static.epg.best/uk/CNN.uk.png" tvg-chno="107" channel-id="107",CNN International HD
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="https://static.epg.best/uk/CNN.uk.png" tvg-chno="107" channel-id="107",CNN International HD
 rtp://239.186.70.23:10000
-#EXTINF:-1 tvg-id="UandDrama.uk" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
+#EXTINF:-1 tvg-id="902" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
 rtp://239.186.66.140:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="109" channel-id="109",DW English HD
 rtp://239.186.70.249:10000
-#EXTINF:-1 tvg-id="E4.uk" tvg-name="E4 UK" tvg-logo="https://static.epg.best/uk/E4.uk.png" tvg-chno="110" channel-id="110",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="https://static.epg.best/uk/E4.uk.png" tvg-chno="110" channel-id="110",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuroNews.uk" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/uk/EuroNews.uk.png" tvg-chno="111" channel-id="111",euronews E HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/uk/EuroNews.uk.png" tvg-chno="111" channel-id="111",euronews E HD
 rtp://239.186.70.105:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="https://static.epg.best/uk/Film4.uk.png" tvg-chno="113" channel-id="113",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="channel5.uk" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="114" channel-id="114",Channel5 CH HD
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="114" channel-id="114",Channel5 CH HD
 rtp://239.186.70.151:10000
-#EXTINF:-1 tvg-id="FoodNetwork.uk" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="i24.il" tvg-name="i24 IL" tvg-logo="https://static.epg.best/uk/i24.il.png" tvg-chno="158" channel-id="158",i24 NEWS E HD
+#EXTINF:-1 tvg-id="Digi24.ro@SD" tvg-name="i24 IL" tvg-logo="https://static.epg.best/uk/i24.il.png" tvg-chno="158" channel-id="158",i24 NEWS E HD
 rtp://239.186.68.140:10000
-#EXTINF:-1 tvg-id="ITV1.uk" tvg-name="ITV1 UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="160" channel-id="160",itv1 HD
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1 UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="160" channel-id="160",itv1 HD
 rtp://239.186.68.42:10000
-#EXTINF:-1 tvg-id="ITV2.uk" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2 HD
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2 HD
 rtp://239.186.84.16:10000
-#EXTINF:-1 tvg-id="ITV3.uk" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3 HD
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3 HD
 rtp://239.186.70.189:10000
-#EXTINF:-1 tvg-id="ITV4.uk" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4 HD
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4 HD
 rtp://239.186.70.150:10000
 #EXTINF:-1 tvg-id="ITVQuiz.uk" tvg-name="ITVQuiz UK" tvg-logo="https://static.epg.best/gb/ITVQuiz.uk.png" tvg-chno="164" channel-id="164",itvQuiz HD
 rtp://239.186.70.245:10000
-#EXTINF:-1 tvg-id="More4.uk" tvg-name="More4 UK" tvg-logo="https://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="https://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorld.jp" tvg-name="NHK World JP" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World JP" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
 rtp://239.186.68.172:10000
-#EXTINF:-1 tvg-id="SkyNews.uk" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky NEWS international
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky NEWS international
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="FiveUSA.uk" tvg-name="5USA UK" tvg-logo="https://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="245" channel-id="245",5USA
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="https://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="245" channel-id="245",5USA
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/uk/PBSAmerica.uk.png" tvg-chno="137" channel-id="137",PBS America
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/uk/PBSAmerica.uk.png" tvg-chno="137" channel-id="137",PBS America
 rtp://239.186.66.243:10000
-#EXTINF:-1 tvg-id="AlJazeeraEnglish.qa" tvg-name="Al Jazeera English QA" tvg-logo="https://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",ALJAZEERA E HD
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="https://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",ALJAZEERA E HD
 rtp://239.186.68.171:10000
-#EXTINF:-1 tvg-id="Dave.uk" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
+#EXTINF:-1 tvg-id="1507" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
 rtp://239.186.66.253:10000
-#EXTINF:-1 tvg-id="Quest.uk" tvg-name="Quest UK" tvg-logo="https://static.epg.best/uk/quest.uk.png" tvg-chno="122" channel-id="122",Quest HD
+#EXTINF:-1 tvg-id="Quest.uk@SD" tvg-name="Quest UK" tvg-logo="https://static.epg.best/uk/quest.uk.png" tvg-chno="122" channel-id="122",Quest HD
 rtp://@239.186.84.2:10000
-#EXTINF:-1 tvg-id="France24E" tvg-name="France 24 E" tvg-logo="https://static.epg.best/fr/France24e.fr.png" tvg-chno="124" channel-id="124",France24 E HD
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 E" tvg-logo="https://static.epg.best/fr/France24e.fr.png" tvg-chno="124" channel-id="124",France24 E HD
 rtp://239.186.84.31:10000
-#EXTINF:-1 tvg-id="5Star.uk" tvg-name="5Star UK" tvg-logo="https://static.epg.best/uk/5star.uk.png" tvg-chno="" channel-id="",5STAR
+#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star UK" tvg-logo="https://static.epg.best/uk/5star.uk.png" tvg-chno="" channel-id="",5STAR
 rtp://239.186.74.72:10000
-#EXTINF:-1 tvg-id="5Select.uk" tvg-name="5Select UK" tvg-logo="https://static.epg.best/uk/5select.uk.png" tvg-chno="" channel-id="",5SELECT
+#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5Select UK" tvg-logo="https://static.epg.best/uk/5select.uk.png" tvg-chno="" channel-id="",5SELECT
 rtp://239.186.74.88:10000
-#EXTINF:-1 tvg-id="5action.uk" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/uk/5action.uk.png" tvg-chno="" channel-id="",5ACTION
+#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/uk/5action.uk.png" tvg-chno="" channel-id="",5ACTION
 rtp://239.186.74.84:10000
-#EXTINF:-1 tvg-id="DiscoveryDMAX.uk" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/uk/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/uk/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
 rtp://239.186.74.74:10000
-#EXTINF:-1 tvg-id="UandYesterday.uk" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="1674" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
-#EXTINF:-1 tvg-id="4Seven.uk" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
+#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="skymix.uk" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
+#EXTINF:-1 tvg-id="2017" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
 rtp://239.186.84.95:10000
-#EXTINF:-1 tvg-id="Challenge.uk" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
+#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
-#EXTINF:-1 tvg-id="Now70s.uk" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",Now 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",Now 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 tvg-id="Now80s.uk" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",Now 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",Now 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="NowRock.uk" tvg-name="Now 90s UK" tvg-logo="https://static.epg.best/gb/NowRocks.uk.png" tvg-chno="" channel-id="",Now Rock
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 90s UK" tvg-logo="https://static.epg.best/gb/NowRocks.uk.png" tvg-chno="" channel-id="",Now Rock
 rtp://239.186.66.133:10000
 #EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/Greatmystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
 #EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/TrueCrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME
 rtp://239.186.74.107:10000
-#EXTINF:-1 tvg-id="GreatRomance.uk" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatClassic.uk.png" tvg-chno="" channel-id="",GREAT! romance
+#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatClassic.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
-#EXTINF:-1 tvg-id="GreatAction.uk" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
+#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
 rtp://239.186.74.58:10000
-#EXTINF:-1 tvg-id="GBNews.uk" tvg-name="GB News UK" tvg-logo="https://static.epg.best/uk/GBNews.uk.png" tvg-chno="" channel-id="",GB News HD
+#EXTINF:-1 tvg-id="GBNews.uk@SD" tvg-name="GB News UK" tvg-logo="https://static.epg.best/uk/GBNews.uk.png" tvg-chno="" channel-id="",GB News HD
 rtp://239.186.84.57:10000
-#EXTINF:-1 ,EU Parliament+ HD
+#EXTINF:-1 tvg-id="1993" ,EU Parliament+ HD
 rtp://239.186.84.42:10000
-#EXTINF:-1 ,EU Parliament HD
+#EXTINF:-1 tvg-id="1992" ,EU Parliament HD
 rtp://239.186.84.45:10000
-#EXTINF:-1 ,CGTN DOCUMENTARY HD
+#EXTINF:-1 tvg-id="2056" ,CGTN DOCUMENTARY HD
 rtp://239.186.84.147:10000
-#EXTINF:-1, Daystar HD (eng)
+#EXTINF:-1tvg-id="StarTV.ch@SD" , Daystar HD (eng)
 rtp://239.186.70.149:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="SRF1.ch" tvg-name="SRF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 FHD
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 FHD
 rtp://239.186.76.3:10000
-#EXTINF:-1 tvg-id="SRF2.ch" tvg-name="SRF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 FHD SRF zwei FHD
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 FHD SRF zwei FHD
 rtp://239.186.76.21:10000
-#EXTINF:-1 tvg-id="SRFInfo.ch" tvg-name="SRF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info FHD
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info FHD
 rtp://239.186.76.23:10000
-#EXTINF:-1 tvg-id="3sat.at" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
+#EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
 rtp://239.186.68.27:10000
-#EXTINF:-1 tvg-id="3Plus.ch" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
+#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
 rtp://239.186.68.14:10000
-#EXTINF:-1 tvg-id="4Plus.ch" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
+#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
 rtp://239.186.68.142:10000
-#EXTINF:-1 tvg-id="5Plus.ch" tvg-name="5+ CH" tvg-logo="https://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
+#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+ CH" tvg-logo="https://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
 rtp://239.186.68.195:10000
-#EXTINF:-1 tvg-id="6Plus.ch" tvg-name="6+ CH" tvg-logo="https://static.epg.best/ch/6Plus.ch.png" tvg-chno="179" channel-id="179",6+ HD
+#EXTINF:-1 tvg-id="6Plus.ch@SD" tvg-name="6+ CH" tvg-logo="https://static.epg.best/ch/6Plus.ch.png" tvg-chno="179" channel-id="179",6+ HD
 rtp://239.186.70.116:10000
-#EXTINF:-1 tvg-id="7Plus.ch" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="239" channel-id="239",7+ HD / Nick D CH HD
+#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="239" channel-id="239",7+ HD / Nick D CH HD
 rtp://239.186.68.175:10000
-#EXTINF:-1 tvg-id="Alf-TV.ch" tvg-name="Alf-TV CH" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
+#EXTINF:-1 tvg-id="1377" tvg-name="Alf-TV CH" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
 rtp://239.186.70.179:10000
 #EXTINF:-1 tvg-id="AW1.de" tvg-name="AW1 DE" tvg-logo="https://static.epg.best/de/AW1.de.png" tvg-chno="180" channel-id="180",aw1 tv HD
 rtp://239.186.70.9:10000
 #EXTINF:-1 tvg-id="AW2.de" tvg-name="AW2 DE" tvg-logo="https://static.epg.best/de/AW2.de.png" tvg-chno="180" channel-id="182",aw2 tv HD
 rtp://239.186.84.22:10000
-#EXTINF:-1 tvg-id="Anixe.de" tvg-name="Anixe DE" tvg-logo="https://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
+#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe DE" tvg-logo="https://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
 rtp://239.186.68.7:10000
-#EXTINF:-1 tvg-id="daserste" tvg-name="Das Erste" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="183" channel-id="183",ARD Das Erste HD
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="183" channel-id="183",ARD Das Erste HD
 rtp://239.186.68.9:10000
-#EXTINF:-1 tvg-id="ARDalpha.de" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha HD
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha HD
 rtp://239.186.70.194:10000
-#EXTINF:-1 tvg-id="One.de" tvg-name="One DE" tvg-logo="https://static.epg.best/de/ARDOne.de.png" tvg-chno="186" channel-id="186",ARD ONE HD
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One DE" tvg-logo="https://static.epg.best/de/ARDOne.de.png" tvg-chno="186" channel-id="186",ARD ONE HD
 rtp://239.186.68.154:10000
-#EXTINF:-1 tvg-id="SRfernsehen.de" tvg-name="SR fernsehen DE" tvg-logo="https://static.epg.best/de/SRfernsehen.de.png" tvg-chno="128" channel-id="128",SR fernsehen HD
+#EXTINF:-1 tvg-id="SRFernsehen.de@SD" tvg-name="SR fernsehen DE" tvg-logo="https://static.epg.best/de/SRfernsehen.de.png" tvg-chno="128" channel-id="128",SR fernsehen HD
 rtp://239.186.70.190:10000
-#EXTINF:-1 tvg-id="ARTE.de" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="188" channel-id="188",arte D HD
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="188" channel-id="188",arte D HD
 rtp://239.186.68.11:10000
-#EXTINF:-1 tvg-id="auftankentv.ch" tvg-name="auftankentv CH" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV CH HD
+#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="auftankentv CH" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV CH HD
 rtp://239.186.70.117:10000
-#EXTINF:-1 tvg-id="pilatus.ch" tvg-name="Pilatus CH" tvg-logo="https://static.epg.best/ch/pilatus.ch.png" tvg-chno="190" channel-id="190",radio Pilatus HD
+#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="Pilatus CH" tvg-logo="https://static.epg.best/ch/pilatus.ch.png" tvg-chno="190" channel-id="190",radio Pilatus HD
 rtp://239.186.68.104:10000
-#EXTINF:-1 tvg-id="BibelTV.de" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
 rtp://239.186.68.148:10000
-#EXTINF:-1 tvg-id="RegioTVBodensee.de" tvg-name="Regio TV Bodensee DE" tvg-logo="https://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
+#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Regio TV Bodensee DE" tvg-logo="https://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
 rtp://239.186.68.143:10000
-#EXTINF:-1 tvg-id="BR.de" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
 rtp://239.186.68.26:10000
-#EXTINF:-1 tvg-id="HelvetiaOne.ch" tvg-name="HELVETIA ONE CH" tvg-logo="https://static.epg.best/ch/helvetiaone.ch.png" tvg-chno="199" channel-id="199",HELVETIA ONE HD
+#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="HELVETIA ONE CH" tvg-logo="https://static.epg.best/ch/helvetiaone.ch.png" tvg-chno="199" channel-id="199",HELVETIA ONE HD
 rtp://239.186.70.103:10000
-#EXTINF:-1 tvg-id="DavosKlosters.ch" tvg-name="Davos Klosters CH" tvg-logo="https://static.epg.best/ch/DavosKlosters.ch.png" tvg-chno="200" channel-id="200",Davos Klosters HD
+#EXTINF:-1 tvg-id="116" tvg-name="Davos Klosters CH" tvg-logo="https://static.epg.best/ch/DavosKlosters.ch.png" tvg-chno="200" channel-id="200",Davos Klosters HD
 rtp://239.186.68.216:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="RiC.de" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",eoTV RiC
+#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",eoTV RiC
 rtp://239.186.64.129:10000
-#EXTINF:-1 tvg-id="HGTV.de" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="129" channel-id="129",HGTV (deu)
+#EXTINF:-1 tvg-id="95" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="129" channel-id="129",HGTV (deu)
 rtp://239.186.74.40:10000
-#EXTINF:-1 tvg-id="Euronews.de" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
 rtp://239.186.70.101:10000
-#EXTINF:-1 tvg-id="HopeChannelInt.de" tvg-name="Hope Channel DE" tvg-logo="https://static.epg.best/de/HopeChannel.de.png" tvg-chno="215" channel-id="215",HopeTV HD
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel DE" tvg-logo="https://static.epg.best/de/HopeChannel.de.png" tvg-chno="215" channel-id="215",HopeTV HD
 rtp://239.186.68.251:10000
-#EXTINF:-1 tvg-id="HR.de" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
 rtp://239.186.68.156:10000
-#EXTINF:-1 tvg-id="HSE24.de" tvg-name="HSE24 DE" tvg-logo="https://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE HD
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE24 DE" tvg-logo="https://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE HD
 rtp://239.186.84.162:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins CH HD
 rtp://239.186.68.15:10000
-#EXTINF:-1 tvg-id="KabelEinsDoku.de" tvg-name="Kabel 1 Doku DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins Doku CH HD
+#EXTINF:-1 tvg-id="kabeleinsDoku.de@SD" tvg-name="Kabel 1 Doku DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins Doku CH HD
 rtp://239.186.70.86:10000
-#EXTINF:-1 tvg-id="Kanal9.ch" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
 rtp://239.186.68.145:10000
-#EXTINF:-1 tvg-id="Kika.de" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
 rtp://239.186.68.28:10000
-#EXTINF:-1 tvg-id="KTV.de" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv HD
+#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv HD
 rtp://239.186.84.137:10000
-#EXTINF:-1 tvg-id="Loly.ch" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY CH HD
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY CH HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
-#EXTINF:-1 tvg-id="melodietv.at" tvg-name="Melodie.tv AT" tvg-logo="https://static.epg.best/at/melodietv.at.png" tvg-chno="231" channel-id="231",Melodie.tv
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="Melodie.tv AT" tvg-logo="https://static.epg.best/at/melodietv.at.png" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="Musig24.ch" tvg-name="Musig24 CH" tvg-logo="https://static.epg.best/ch/Musig24.ch.png" tvg-chno="234" channel-id="234",musig24 HD
+#EXTINF:-1 tvg-id="Musig24TV.ch@SD" tvg-name="Musig24 CH" tvg-logo="https://static.epg.best/ch/Musig24.ch.png" tvg-chno="234" channel-id="234",musig24 HD
 rtp://239.186.68.207:10000
-#EXTINF:-1 tvg-id="N24Doku.de" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
-#EXTINF:-1 tvg-id="RTLNitro.de" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
-#EXTINF:-1 tvg-id="ORF1.at" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="245" channel-id="245",ORF1 HD
+#EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="245" channel-id="245",ORF1 HD
 rtp://239.186.68.12:10000
-#EXTINF:-1 tvg-id="ORF2.at" tvg-name="ORF 2" tvg-logo="https://static.epg.best/at/ORF2.at.png" tvg-chno="247" channel-id="247",ORF2 HD
+#EXTINF:-1 tvg-id="ORF2.at@SD" tvg-name="ORF 2" tvg-logo="https://static.epg.best/at/ORF2.at.png" tvg-chno="247" channel-id="247",ORF2 HD
 rtp://239.186.68.13:10000
-#EXTINF:-1 tvg-id="ORF3.at" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
+#EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="Phoenix.de" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
 rtp://239.186.68.30:10000
-#EXTINF:-1 tvg-id="ProSieben.de" tvg-name="ProSieben DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben CH HD
+#EXTINF:-1 tvg-id="ProSiebenSchweiz.ch@SD" tvg-name="ProSieben DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben CH HD
 rtp://239.186.68.17:10000
-#EXTINF:-1 tvg-id="ProSiebenMaxx.de" tvg-name="ProSieben Maxx DE" tvg-logo="https://static.epg.best/de/ProSiebenMaxx.de.png" tvg-chno="252" channel-id="252",ProSieben MAXX CH HD
+#EXTINF:-1 tvg-id="ProSiebenMaxx.de@SD" tvg-name="ProSieben Maxx DE" tvg-logo="https://static.epg.best/de/ProSiebenMaxx.de.png" tvg-chno="252" channel-id="252",ProSieben MAXX CH HD
 rtp://239.186.70.87:10000
 #EXTINF:-1 tvg-id="PULSacht.ch" tvg-name="Puls acht CH" tvg-logo="https://static.epg.best/ch/PULSacht.ch.png" tvg-chno="254" channel-id="254",Puls acht HD
 rtp://239.186.68.191:10000
 #EXTINF:-1 tvg-id="r-9.at" tvg-name="R-9 AT" tvg-logo="https://static.epg.best/at/r-9.at.png" tvg-chno="255" channel-id="255",R9 Oesterreich HD
 rtp://239.186.68.248:10000
-#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
+#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
 rtp://239.186.68.157:10000
-#EXTINF:-1 tvg-id="RegioTVplus.ch" tvg-name="Regio TVplus CH" tvg-logo="https://static.epg.best/de/RegioTVplus.ch.png" tvg-chno="258" channel-id="258",regioTVplus HD
+#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="Regio TVplus CH" tvg-logo="https://static.epg.best/de/RegioTVplus.ch.png" tvg-chno="258" channel-id="258",regioTVplus HD
 rtp://239.186.70.40:10000
-#EXTINF:-1 tvg-id="Rheinwelten.ch" tvg-name="Rheinwelten CH" tvg-logo="https://static.epg.best/de/Rheinwelten.ch.png" tvg-chno="132" channel-id="132",Rheinwelten HD
+#EXTINF:-1 tvg-id="RheinweltenTV.ch@SD" tvg-name="Rheinwelten CH" tvg-logo="https://static.epg.best/de/Rheinwelten.ch.png" tvg-chno="132" channel-id="132",Rheinwelten HD
 rtp://239.186.70.202:10000
-#EXTINF:-1 tvg-id="RTL.de" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="RTL2.de" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="RTLup.de" tvg-name="RTL Plus DE" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL Plus DE" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="S1.ch" tvg-name="S1 CH" tvg-logo="https://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
+#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1 CH" tvg-logo="https://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
-#EXTINF:-1 tvg-id="Sat1.de" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH HD
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH HD
 rtp://239.186.68.16:10000
-#EXTINF:-1 tvg-id="Sat1Gold.de" tvg-name="Sat 1 Gold DE" tvg-logo="https://static.epg.best/de/Sat1Gold.de.png" tvg-chno="265" channel-id="265",SAT.1 GOLD CH HD
+#EXTINF:-1 tvg-id="SAT1Gold.de@SD" tvg-name="Sat 1 Gold DE" tvg-logo="https://static.epg.best/de/Sat1Gold.de.png" tvg-chno="265" channel-id="265",SAT.1 GOLD CH HD
 rtp://239.186.70.88:10000
-#EXTINF:-1 tvg-id="ServusTV.de" tvg-name="ServusTV DE" tvg-logo="https://static.epg.best/de/ServusTV.de.png" tvg-chno="270" channel-id="270",ServusTV Deutschland
+#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="ServusTV DE" tvg-logo="https://static.epg.best/de/ServusTV.de.png" tvg-chno="270" channel-id="270",ServusTV Deutschland
 rtp://239.186.64.136:10000
-#EXTINF:-1 tvg-id="SessionNationalrat.ch" tvg-name="Session Nationalrat CH" tvg-logo="https://static.epg.best/ch/SessionNationalrat.ch.png" tvg-chno="272" channel-id="272",SessionNationalrat HD
+#EXTINF:-1 tvg-id="1325" tvg-name="Session Nationalrat CH" tvg-logo="https://static.epg.best/ch/SessionNationalrat.ch.png" tvg-chno="272" channel-id="272",SessionNationalrat HD
 rtp://239.186.70.127:10000
 #EXTINF:-1 tvg-id="SessionStaendenrat.ch" tvg-name="SessionStaendenrat CH" tvg-logo="https://static.epg.best/ch/SessionStaendenrat.ch.png" tvg-chno="274" channel-id="274",SessionStaendenrat HD
 rtp://239.186.70.128:10000
-#EXTINF:-1 tvg-id="SHf.ch" tvg-name="SHf CH" tvg-logo="https://static.epg.best/ch/SHf.ch.png" tvg-chno="277" channel-id="277",SHf HD
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf CH" tvg-logo="https://static.epg.best/ch/SHf.ch.png" tvg-chno="277" channel-id="277",SHf HD
 rtp://239.186.68.139:10000
-#EXTINF:-1 tvg-id="sixx.de" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH HD
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH HD
 rtp://239.186.68.34:10000
-#EXTINF:-1 tvg-id="Sport1.de" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",Sport1 CH HD
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",Sport1 CH HD
 rtp://239.186.68.159:10000
-#EXTINF:-1 tvg-id="StarTV.ch" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",STAR TV CH HD
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",STAR TV CH HD
 rtp://239.186.68.188:10000
-#EXTINF:-1 tvg-id="gametv.ch" tvg-name="GameTV CH" tvg-logo="https://static.epg.best/ch/Gametv.ch.png" tvg-chno="289" channel-id="289",GAMETV CH HD
+#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="GameTV CH" tvg-logo="https://static.epg.best/ch/Gametv.ch.png" tvg-chno="289" channel-id="289",GAMETV CH HD
 rtp://239.186.70.10:10000
-#EXTINF:-1 tvg-id="SuperRTL.de" tvg-name="Super RTL DE" tvg-logo="https://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",RTL SUPER
+#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL DE" tvg-logo="https://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",RTL SUPER
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="Swiss1.ch" tvg-name="Swiss1 CH" tvg-logo="https://static.epg.best/ch/Swiss1.ch.png" tvg-chno="292" channel-id="292",Swiss1 HD
+#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="Swiss1 CH" tvg-logo="https://static.epg.best/ch/Swiss1.ch.png" tvg-chno="292" channel-id="292",Swiss1 HD
 rtp://239.186.68.97:10000
-#EXTINF:-1 tvg-id="SWRSR.de" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="294" channel-id="294",SWR >> HD
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="294" channel-id="294",SWR >> HD
 rtp://239.186.68.25:10000
-#EXTINF:-1 tvg-id="Tagesschau24.de" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="296" channel-id="296",Tagesschau24 HD
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="296" channel-id="296",Tagesschau24 HD
 rtp://239.186.68.161:10000
-#EXTINF:-1 tvg-id="Tele1.ch" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="298" channel-id="298",Tele1 HD
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="298" channel-id="298",Tele1 HD
 rtp://239.186.68.176:10000
-#EXTINF:-1 tvg-id="TeleBaern.ch" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",telebaern.tv HD
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",telebaern.tv HD
 rtp://239.186.68.38:10000
-#EXTINF:-1 tvg-id="teled.ch" tvg-name="TELE D CH" tvg-logo="https://static.epg.best/ch/teled.ch.png" tvg-chno="304" channel-id="304",TELE D HD
+#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="TELE D CH" tvg-logo="https://static.epg.best/ch/teled.ch.png" tvg-chno="304" channel-id="304",TELE D HD
 rtp://239.186.68.217:10000
-#EXTINF:-1 tvg-id="TeleM1.ch" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
 rtp://239.186.68.102:10000
-#EXTINF:-1 tvg-id="TeleTop.ch" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
 rtp://239.186.68.252:10000
-#EXTINF:-1 tvg-id="televista.ch" tvg-name="televista CH" tvg-logo="https://static.epg.best/ch/televista.ch.png" tvg-chno="163" channel-id="163",TELEVISTA HD
+#EXTINF:-1 tvg-id="Televista.ch@SD" tvg-name="televista CH" tvg-logo="https://static.epg.best/ch/televista.ch.png" tvg-chno="163" channel-id="163",TELEVISTA HD
 rtp://239.186.70.182:10000
-#EXTINF:-1 tvg-id="telez.ch" tvg-name="TELE Z CH" tvg-logo="https://static.epg.best/ch/telez.ch.png" tvg-chno="310" channel-id="310",TELEZ HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="TELE Z CH" tvg-logo="https://static.epg.best/ch/telez.ch.png" tvg-chno="310" channel-id="310",TELEZ HD
 rtp://239.186.68.205:10000
-#EXTINF:-1 tvg-id="TeleZentral.ch" tvg-name="Tele Zentral CH" tvg-logo="https://static.epg.best/ch/TeleZentral.ch.png" tvg-chno="311" channel-id="311",Tele Zentral Schweiz HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zentral CH" tvg-logo="https://static.epg.best/ch/TeleZentral.ch.png" tvg-chno="311" channel-id="311",Tele Zentral Schweiz HD
 rtp://239.186.68.166:10000
-#EXTINF:-1 tvg-id="TeleZueri.ch" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
 rtp://239.186.68.189:10000
-#EXTINF:-1 tvg-id="TeleBasel.ch" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
 rtp://239.186.68.206:10000
-#EXTINF:-1 tvg-id="BlueZoomD.ch" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="317" channel-id="317",blue ZOOM D HD
+#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="317" channel-id="317",blue ZOOM D HD
 rtp://239.186.68.155:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
-#EXTINF:-1 tvg-id="TeleSuedostschweiz.ch" tvg-name="Tele Suedostschweiz CH" tvg-logo="https://static.epg.best/ch/TeleSuedostschweiz.ch.png" tvg-chno="322" channel-id="322",TSO TeleSuedostschweiz HD
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="Tele Suedostschweiz CH" tvg-logo="https://static.epg.best/ch/TeleSuedostschweiz.ch.png" tvg-chno="322" channel-id="322",TSO TeleSuedostschweiz HD
 rtp://239.186.68.218:10000
-#EXTINF:-1 tvg-id="TVOberwallis.ch" tvg-name="TV Oberwallis CH" tvg-logo="https://static.epg.best/ch/TVOberwallis.ch.png" tvg-chno="324" channel-id="324",TV Oberwallis HD
+#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="TV Oberwallis CH" tvg-logo="https://static.epg.best/ch/TVOberwallis.ch.png" tvg-chno="324" channel-id="324",TV Oberwallis HD
 rtp://239.186.70.5:10000
-#EXTINF:-1 tvg-id="TV24.ch" tvg-name="TV24 CH" tvg-logo="https://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
+#EXTINF:-1 tvg-id="1910" tvg-name="TV24 CH" tvg-logo="https://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
 rtp://239.186.68.190:10000
 #EXTINF:-1 tvg-id="TV25.ch" tvg-name="TV 25 CH" tvg-logo="https://static.epg.best/ch/TV25.ch.png" tvg-chno="327" channel-id="327",TV25 HD
 rtp://239.186.70.20:10000
-#EXTINF:-1 tvg-id="TVO.ch" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
 rtp://239.186.70.4:10000
-#EXTINF:-1 tvg-id="Vox.de" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
-#EXTINF:-1 tvg-id="Welt.de" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="WeltDerWunder.de" tvg-name="Welt der Wunder DE" tvg-logo="https://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV CH HD
+#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder DE" tvg-logo="https://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV CH HD
 rtp://239.186.68.198:10000
-#EXTINF:-1 tvg-id="Wettertv.ch" tvg-name="WetterTV CH" tvg-logo="https://static.epg.best/ch/Wettertv.ch.png" tvg-chno="338" channel-id="338",wetter.tv CH HD
+#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="WetterTV CH" tvg-logo="https://static.epg.best/ch/Wettertv.ch.png" tvg-chno="338" channel-id="338",wetter.tv CH HD
 rtp://239.186.70.119:10000
-#EXTINF:-1 tvg-id="ZDF.de" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
 rtp://239.186.68.10:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
 rtp://239.186.68.32:10000
-#EXTINF:-1 tvg-id="ZDFneo.de" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
 rtp://239.186.68.31:10000
-#EXTINF:-1 tvg-id="VOXup.de" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="135" channel-id="135",VOXup
+#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="135" channel-id="135",VOXup
 rtp://239.186.74.70:10000
-#EXTINF:-1 tvg-id="SwissSportTV.ch" tvg-name="SwissSportTV CH" tvg-logo="https://static.epg.best/ch/swisssporttv.ch.png" tvg-chno="139" channel-id="139",swiss sport tv HD
+#EXTINF:-1 tvg-id="SwissSportTV.ch@SD" tvg-name="SwissSportTV CH" tvg-logo="https://static.epg.best/ch/swisssporttv.ch.png" tvg-chno="139" channel-id="139",swiss sport tv HD
 rtp://@239.186.84.17:10000
-#EXTINF:-1 tvg-id="SchlagerDeluxe.de" tvg-name="Schlager Deluxe DE" tvg-logo="https://static.epg.best/de/SchlagerDeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
+#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="Schlager Deluxe DE" tvg-logo="https://static.epg.best/de/SchlagerDeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
 rtp://239.186.74.105:10000
-#EXTINF:-1 tvg-id="SchlagerParadies.de" tvg-name="Schlager Paradies DE" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
+#EXTINF:-1 tvg-id="1903" tvg-name="Schlager Paradies DE" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
 rtp://239.186.84.37:10000
-#EXTINF:-1 tvg-id="VolksmusikTV.de" tvg-name="Volksmusik TV DE" tvg-logo="https://static.epg.best/de/Volksmusik.de.png" tvg-chno="" channel-id="",Volksmusik.tv HD
+#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="Volksmusik TV DE" tvg-logo="https://static.epg.best/de/Volksmusik.de.png" tvg-chno="" channel-id="",Volksmusik.tv HD
 rtp://239.186.70.97:10000
-#EXTINF:-1 ,More Than Sports TV HD
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" ,More Than Sports TV HD
 rtp://239.186.70.28:10000
-#EXTINF:-1 ,Folx HD
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" ,Folx HD
 rtp://239.186.68.121:10000
-#EXTINF:-1 tvg-id="ONEmusic.de" tvg-name="One Music DE" tvg-logo="https://static.epg.best/de/onemusic.de.png" tvg-chno="" channel-id="",ONE 1 Music TV HD
+#EXTINF:-1 tvg-id="OneMusicTelevision.de@SD" tvg-name="One Music DE" tvg-logo="https://static.epg.best/de/onemusic.de.png" tvg-chno="" channel-id="",ONE 1 Music TV HD
 rtp://239.186.70.214:10000
-#EXTINF:-1 tvg-id="ZWEImusic.de" tvg-name="Zwei Music DE" tvg-logo="https://static.epg.best/de/zweimusic.de.png" tvg-chno="" channel-id="",ZWEI 2 Music TV HD
+#EXTINF:-1 tvg-id="ZweiMusicTelevision.de@SD" tvg-name="Zwei Music DE" tvg-logo="https://static.epg.best/de/zweimusic.de.png" tvg-chno="" channel-id="",ZWEI 2 Music TV HD
 rtp://239.186.70.204:10000
-#EXTINF:-1 tvg-id="MarcoPoloTV.de" tvg-name="Marco Polo TV DE" tvg-logo="https://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="" channel-id="",MARCO POLO TV HD
+#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo TV DE" tvg-logo="https://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="" channel-id="",MARCO POLO TV HD
 rtp://239.186.84.60:10000
-#EXTINF:-1 tvg-id="ORFsport.at" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORFSport.at.png" tvg-chno="249" channel-id="249",ORF SPORT+ HD
+#EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORFSport.at.png" tvg-chno="249" channel-id="249",ORF SPORT+ HD
 rtp://239.186.84.80:10000
-#EXTINF:-1 tvg-id="ArcadiaTV.ro" tvg-name="Arcadia TV RO" tvg-logo="https://static.epg.best/ro/ArcadiaTV.ro.png" tvg-chno="" channel-id="" ,ARCADIA WORLD TV HD
+#EXTINF:-1 tvg-id="ArcadiaTV.li@SD" tvg-name="Arcadia TV RO" tvg-logo="https://static.epg.best/ro/ArcadiaTV.ro.png" tvg-chno="" channel-id="" ,ARCADIA WORLD TV HD
 rtp://239.186.84.1:10000
 #EXTINF:-1 ,DMF HD
 rtp://239.186.70.96:10000
-#EXTINF:-1 ,stimmungsgarten.tv
+#EXTINF:-1 tvg-id="2055" ,stimmungsgarten.tv
 rtp://239.186.74.148:10000
-#EXTINF:-1 ,justcooking.tv (deu)
+#EXTINF:-1 tvg-id="2041" ,justcooking.tv (deu)
 rtp://239.186.74.150:10000
-#EXTINF:-1 ,TV RT HD (deu) TV   TV Rheintal HD
+#EXTINF:-1 tvg-id="TVRheintal.ch@SD" ,TV RT HD (deu) TV   TV Rheintal HD
 rtp://239.186.84.171:10000
 #EXTINF:-1 ,I-TV HD
 rtp://239.186.70.91:10000
@@ -463,170 +463,170 @@ rtp://239.186.74.157:10000
 rtp://239.186.70.126:10000
 #EXTINF:-1 ,DF1 HD (deu)
 rtp://239.186.68.93:10000
-#EXTINF:-1,TELEGOLD HD (deu)
+#EXTINF:-1tvg-id="TeleD.ch@SD" ,TELEGOLD HD (deu)
 rtp://239.186.68.53:10000
 #EXTINF:-1,Hohenrausch HD
 rtp://239.186.70.140:10000
-#EXTINF:-1,lilo TV
+#EXTINF:-1tvg-id="LiloTV.de@SD" ,lilo TV
 rtp://239.186.74.82:10000
-#EXTINF:-1,network tv HD
+#EXTINF:-1tvg-id="1065" ,network tv HD
 rtp://239.186.84.173:10000
-#EXTINF:-1 tvg-id="ntv.de" tvg-name="ntv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="340" channel-id="",ntv
+#EXTINF:-1 tvg-id="296" tvg-name="ntv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="340" channel-id="",ntv
 rtp://239.186.64.29:10000
-#EXTINF:-1 tvg-id="canalbde.ch" tvg-name="canalbde CH" tvg-logo="https://static.epg.best/ch/canalbde.ch.png" tvg-chno="" channel-id="",Canalb de HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="canalbde CH" tvg-logo="https://static.epg.best/ch/canalbde.ch.png" tvg-chno="" channel-id="",Canalb de HD
 rtp://239.186.70.173:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILA1.ch" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
 rtp://239.186.76.24:10000
-#EXTINF:-1 tvg-id="RSILA2.ch" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 FHD
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 FHD
 rtp://239.186.76.25:10000
-#EXTINF:-1 tvg-id="teleticino.ch" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="411" channel-id="411",teleticino HD
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="411" channel-id="411",teleticino HD
 rtp://239.186.68.201:10000
 #EXTINF:-1 tvg-id="7GTelecity.it" tvg-name="7G Telecity IT" tvg-logo="https://static.epg.best/it/7GTelecity.it.png" tvg-chno="346" channel-id="346",telecity HD
 rtp://239.186.84.109:10000
-#EXTINF:-1 tvg-id="almatv.it" tvg-name="Almatv IT" tvg-logo="https://static.epg.best/it/almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
+#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="Almatv IT" tvg-logo="https://static.epg.best/it/almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="antenna3.it" tvg-name="antenna3 IT" tvg-logo="https://static.epg.best/it/antenna3.it.png" tvg-chno="348" channel-id="348",ANTENNA3 HD
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="antenna3 IT" tvg-logo="https://static.epg.best/it/antenna3.it.png" tvg-chno="348" channel-id="348",ANTENNA3 HD
 rtp://239.186.70.79:10000
-#EXTINF:-1 tvg-id="canaleitalia.it" tvg-name="Canale Italia IT" tvg-logo="https://static.epg.best/it/canaleitalia.it.png" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="Canale Italia IT" tvg-logo="https://static.epg.best/it/canaleitalia.it.png" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Cielo.it" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo HD
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo HD
 rtp://239.186.70.172:10000
-#EXTINF:-1 tvg-id="ClassTVModa.it" tvg-name="ClassTV Moda IT" tvg-logo="https://static.epg.best/it/ClassTVModa.it.png" tvg-chno="354" channel-id="354",Class TV Moda HD
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="ClassTV Moda IT" tvg-logo="https://static.epg.best/it/ClassTVModa.it.png" tvg-chno="354" channel-id="354",Class TV Moda HD
 rtp://239.186.84.180:10000
-#EXTINF:-1 tvg-id="discovery.it" tvg-name="Discovery IT" tvg-logo="https://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I HD
+#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="Discovery IT" tvg-logo="https://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I HD
 rtp://239.186.68.149:10000
-#EXTINF:-1 tvg-id="RealTime.it" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros. Discovery Real Time HD
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros. Discovery Real Time HD
 rtp://239.186.84.103:10000
-#EXTINF:-1 tvg-id="NOVE.it" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="361" channel-id="361",Warner Bros. Discovery NOVE HD
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="361" channel-id="361",Warner Bros. Discovery NOVE HD
 rtp://239.186.70.233:10000
-#EXTINF:-1 tvg-id="DMAX.it" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros. Discovery DMAX I HD
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros. Discovery DMAX I HD
 rtp://239.186.84.89:10000
-#EXTINF:-1 tvg-id="Giallo.it" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros. Discovery Giallo HD
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros. Discovery Giallo HD
 rtp://239.186.84.99:10000
-#EXTINF:-1 tvg-id="MotorTrend.us" tvg-name="Motor Trend US" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend US" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
 rtp://239.186.84.102:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros. Discovery food network I HD
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros. Discovery food network I HD
 rtp://239.186.84.91:10000
-#EXTINF:-1 tvg-id="K2.it" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros. Discovery K2
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros. Discovery K2
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="Frisbee.it" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros. Discovery Frisbee
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros. Discovery Frisbee
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="HGTV.it" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
+#EXTINF:-1 tvg-id="95" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
 rtp://239.186.84.101:10000
-#EXTINF:-1 tvg-id="Euronews.it" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
-#EXTINF:-1 tvg-id="ItaliaChannel.it" tvg-name="Italia Channel IT" tvg-logo="https://static.epg.best/it/ItaliaChannel.it.png" tvg-chno="365" channel-id="365",Italia Channel 123
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="Italia Channel IT" tvg-logo="https://static.epg.best/it/ItaliaChannel.it.png" tvg-chno="365" channel-id="365",Italia Channel 123
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="La7.it" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
 rtp://239.186.70.7:10000
-#EXTINF:-1 tvg-id="La7cinema.it" tvg-name="La7cinama IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7cinama IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA HD
 rtp://239.186.70.6:10000
-#EXTINF:-1 tvg-id="Canale5.it" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
 rtp://239.186.68.163:10000
-#EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
 rtp://239.186.68.165:10000
 #EXTINF:-1 tvg-id="ReteQuattro.it" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4 HD
 rtp://239.186.70.188:10000
-#EXTINF:-1 tvg-id="20Mediaset.it" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET HD
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET HD
 rtp://239.186.68.46:10000
-#EXTINF:-1 tvg-id="La5.it" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5 HD
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5 HD
 rtp://239.186.84.88:10000
-#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2 HD
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2 HD
 rtp://239.186.84.123:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA HD
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA HD
 rtp://239.186.68.128:10000
-#EXTINF:-1 tvg-id="FocusTv.it" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus HD
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus HD
 rtp://239.186.70.72:10000
-#EXTINF:-1 tvg-id="TopCrime.it" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime HD
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime HD
 rtp://239.186.84.125:10000
-#EXTINF:-1 tvg-id="Iris.it" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS HD
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS HD
 rtp://239.186.84.98:10000
-#EXTINF:-1 tvg-id="Boing.it" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing HD
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing HD
 rtp://239.186.84.142:10000
-#EXTINF:-1 tvg-id="Cartoonito.it" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",CARTOONITO HD
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",CARTOONITO HD
 rtp://239.186.84.139:10000
-#EXTINF:-1 tvg-id="Tgcom24.it" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCom24 HD
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCom24 HD
 rtp://239.186.84.86:10000
-#EXTINF:-1 tvg-id="Cine34.it" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34 HD
+#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34 HD
 rtp://239.186.68.245:10000
-#EXTINF:-1 tvg-id="twentyseven.it" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 HD
+#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 HD
 rtp://239.186.84.87:10000
-#EXTINF:-1 tvg-id="RaiUno.it" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
 rtp://239.186.68.36:10000
-#EXTINF:-1 tvg-id="RaiDue.it" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
 rtp://239.186.70.77:10000
-#EXTINF:-1 tvg-id="RaiTre.it" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
 rtp://239.186.70.78:10000
-#EXTINF:-1 tvg-id="Rai4.it" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4 HD
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4 HD
 rtp://239.186.70.43:10000
-#EXTINF:-1 tvg-id="Rai5.it" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiMovie.it" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie HD
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie HD
 rtp://239.186.84.140:10000
-#EXTINF:-1 tvg-id="RaiPremium.it" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium FullHD
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium FullHD
 rtp://239.186.76.2:10000
-#EXTINF:-1 tvg-id="RaiGulp.it" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp HD
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp HD
 rtp://239.186.84.18:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="RaiStoria.it" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia HD
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia HD
 rtp://239.186.70.110:10000
-#EXTINF:-1 tvg-id="RaiScuola.it" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola HD
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola HD
 rtp://239.186.70.111:10000
-#EXTINF:-1 tvg-id="RaiNews.it" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24 HD
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24 HD
 rtp://239.186.70.84:10000
-#EXTINF:-1 tvg-id="RaiSportPlus.it" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport HD
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport HD
 rtp://239.186.70.2:10000
-#EXTINF:-1 tvg-id="radionorba.it" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="140" channel-id="140",radionorba TV HD
+#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="140" channel-id="140",radionorba TV HD
 rtp://239.186.84.20:10000
-#EXTINF:-1 tvg-id="RTL1025TV.it" tvg-name="RTL102.5TV IT" tvg-logo="https://static.epg.best/it/RTL1025TV.it.png" tvg-chno="141" channel-id="141",RTL 102.5 TV HD
+#EXTINF:-1 tvg-id="RTL1025TV.it@SD" tvg-name="RTL102.5TV IT" tvg-logo="https://static.epg.best/it/RTL1025TV.it.png" tvg-chno="141" channel-id="141",RTL 102.5 TV HD
 rtp://239.186.70.181:10000
-#EXTINF:-1 tvg-id="SkyTG24.it" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24 HD
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24 HD
 rtp://239.186.70.109:10000
-#EXTINF:-1 tvg-id="Sportitalia.it" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport italia plus HD
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport italia plus HD
 rtp://239.186.70.14:10000
-#EXTINF:-1 tvg-id="SoloCalcio.it" tvg-name="SoloCalcio IT" tvg-logo="https://static.epg.best/it/SoloCalcio.it.png" tvg-chno="407" channel-id="407",Si SOLOCALCIO HD
+#EXTINF:-1 tvg-id="2049" tvg-name="SoloCalcio IT" tvg-logo="https://static.epg.best/it/SoloCalcio.it.png" tvg-chno="407" channel-id="407",Si SOLOCALCIO HD
 rtp://239.186.84.94:10000
-#EXTINF:-1 tvg-id="super.it" tvg-name="super! IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="super! IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="SuperTennis.it" tvg-name="SuperTennis IT" tvg-logo="https://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SuperTennis HD
+#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis IT" tvg-logo="https://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SuperTennis HD
 rtp://239.186.70.154:10000
-#EXTINF:-1 tvg-id="telelombardia.it" tvg-name="telelombardia IT" tvg-logo="https://static.epg.best/it/telelombardia.it.png" tvg-chno="412" channel-id="412",TELELOMBARDIA HD
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="telelombardia IT" tvg-logo="https://static.epg.best/it/telelombardia.it.png" tvg-chno="412" channel-id="412",TELELOMBARDIA HD
 rtp://239.186.84.104:10000
-#EXTINF:-1 tvg-id="telenova.it" tvg-name="telenova IT" tvg-logo="https://static.epg.best/it/telenova.it.png" tvg-chno="413" channel-id="413",TELENOVA HD
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="telenova IT" tvg-logo="https://static.epg.best/it/telenova.it.png" tvg-chno="413" channel-id="413",TELENOVA HD
 rtp://239.186.84.113:10000
-#EXTINF:-1 tvg-id="TV8.it" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",TV8 Italia HD
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",TV8 Italia HD
 rtp://239.186.84.28:10000
-#EXTINF:-1 tvg-id="uninettuno.it" tvg-name="Uninettuno IT" tvg-logo="https://static.epg.best/it/uninettuno.it" tvg-chno="417" channel-id="417",UNINETTUNO.tv
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="Uninettuno IT" tvg-logo="https://static.epg.best/it/uninettuno.it" tvg-chno="417" channel-id="417",UNINETTUNO.tv
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="TV2000.it" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000 HD
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000 HD
 rtp://239.186.84.73:10000
-#EXTINF:-1 tvg-id="Espansione.it" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/Espansione.it.png" tvg-chno="414" channel-id="414",Espansione TV HD
+#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/Espansione.it.png" tvg-chno="414" channel-id="414",Espansione TV HD
 rtp://239.186.84.90:10000
-#EXTINF:-1 tvg-id="Topcalcio24.it" tvg-name="Topcalcio24 IT" tvg-logo="https://static.epg.best/it/Topcalcio24.it.png" tvg-chno="420" channel-id="420",TOP CALCIO 24 HD
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Topcalcio24 IT" tvg-logo="https://static.epg.best/it/Topcalcio24.it.png" tvg-chno="420" channel-id="420",TOP CALCIO 24 HD
 rtp://239.186.84.105:10000
-#EXTINF:-1 ,Senato TV HD
+#EXTINF:-1 tvg-id="SenatoTV.it@SD" ,Senato TV HD
 rtp://239.186.70.114:10000
-#EXTINF:-1 tvg-id="DeejayTV.it" tvg-name="DeejayTV IT" tvg-logo="https://static.epg.best/it/Deejay.it.png" tvg-chno="" channel-id="",Deejay TV HD
+#EXTINF:-1 tvg-id="DeejayTV.it@SD" tvg-name="DeejayTV IT" tvg-logo="https://static.epg.best/it/Deejay.it.png" tvg-chno="" channel-id="",Deejay TV HD
 rtp://239.186.70.152:10000
-#EXTINF:-1 tvg-id="SMtvSanMarino.it" tvg-name="SMtv San Marino IT" tvg-logo="https://static.epg.best/it/SMtvSanMarino.it.png" tvg-chno="" channel-id="",Rtv San Marino HD
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="SMtv San Marino IT" tvg-logo="https://static.epg.best/it/SMtvSanMarino.it.png" tvg-chno="" channel-id="",Rtv San Marino HD
 rtp://239.186.84.23:10000
-#EXTINF:-1 ,camera dei deputati
+#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD" ,camera dei deputati
 rtp://239.186.74.59:10000
-#EXTINF:-1 ,Radio Ticino channel HD
+#EXTINF:-1 tvg-id="RadioTicinoChannel.it@SD" ,Radio Ticino channel HD
 rtp://239.186.68.192:10000
-#EXTINF:-1 ,Parole Di Vita HD
+#EXTINF:-1 tvg-id="ParolediVita.it@SD" ,Parole Di Vita HD
 rtp://239.186.68.179:10000
-#EXTINF:-1 ,TRENTINO TV HD
+#EXTINF:-1 tvg-id="2060" ,TRENTINO TV HD
 rtp://239.186.84.141:10000
-#EXTINF:-1 ,telenuovo HD
+#EXTINF:-1 tvg-id="2057" ,telenuovo HD
 rtp://239.186.84.143:10000
-#EXTINF:-1 ,CAPRI SPORT HD
+#EXTINF:-1 tvg-id="2061" ,CAPRI SPORT HD
 rtp://239.186.84.150:10000
-#EXTINF:-1 ,RADIO ITALIA HD
+#EXTINF:-1 tvg-id="2064" ,RADIO ITALIA HD
 rtp://239.186.84.152:10000
-#EXTINF:-1 ,TELECUPOLE HD
+#EXTINF:-1 tvg-id="2063" ,TELECUPOLE HD
 rtp://239.186.84.156:10000
 #EXTINF:-1 ,R55 Rete55 TV HD (ita)
 rtp://239.186.84.178:10000
@@ -635,148 +635,148 @@ rtp://239.186.70.33:10000
 #EXTINF:-1,wedotv Movies IT HD (ita)
 rtp://239.186.70.169:10000
 #EXTREM:portuguese
-#EXTINF:-1 tvg-id="RecordTV.br" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP mundo_.
+#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP mundo_.
 rtp://239.186.64.77:10000
 #EXTREM:spanish
-#EXTINF:-1 tvg-id="Aragonint.es" tvg-name="Aragon int ES" tvg-logo="https://static.epg.best/es/aragonint.es.png" tvg-chno="143" channel-id="143",Aragon int
+#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragon int ES" tvg-logo="https://static.epg.best/es/aragonint.es.png" tvg-chno="143" channel-id="143",Aragon int
 rtp://239.186.66.62:10000
-#EXTINF:-1 tvg-id="24Horas.es" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas HD
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas HD
 rtp://239.186.68.45:10000
-#EXTINF:-1 tvg-id="CanalAndalucia.es" tvg-name="Canal Sur Andalucía ES" tvg-logo="https://static.epg.best/es/CanalAndalucia.es.png" tvg-chno="467" channel-id="467",Andalucia TV
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="Canal Sur Andalucía ES" tvg-logo="https://static.epg.best/es/CanalAndalucia.es.png" tvg-chno="467" channel-id="467",Andalucia TV
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="TVGalicia.es" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",TV Galicia HD
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",TV Galicia HD
 rtp://239.186.84.33:10000
-#EXTINF:-1 tvg-id="TVEIntEu.es" tvg-name="TVE Internacional Europa/África ES" tvg-logo="https://static.epg.best/es/TVEIntEu.es.png" tvg-chno="469" channel-id="469",tve int HD
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="TVE Internacional Europa/África ES" tvg-logo="https://static.epg.best/es/TVEIntEu.es.png" tvg-chno="469" channel-id="469",tve int HD
 rtp://239.186.68.178:10000
-#EXTINF:-1 tvg-id="Telesur.es" tvg-name="Telesur ES" tvg-logo="https://static.epg.best/es/Telesur.es.png" tvg-chno="" channel-id="",teleSUR HD (spa)
+#EXTINF:-1 tvg-id="Telesur.ve@SD" tvg-name="Telesur ES" tvg-logo="https://static.epg.best/es/Telesur.es.png" tvg-chno="" channel-id="",teleSUR HD (spa)
 rtp://239.186.84.19:10000
 #EXTINF:-1 ,cvi HD Cuba Visio Internacional
 rtp://239.186.84.146:10000
 #EXTREM:turkish
-#EXTINF:-1 tvg-id="EuroD.tr" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",Euro D HD
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",Euro D HD
 rtp://239.186.84.138:10000
-#EXTINF:-1 tvg-id="Eurostar.tr" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id=""360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk HD
+#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk HD
 rtp://239.186.70.184:10000
-#EXTINF:-1 tvg-id="atv.tr" tvg-name="ATV TR" tvg-logo="https://static.epg.best/tr/ATV.tr.png" tvg-chno="421" channel-id="421",atv avrupa HD
+#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="ATV TR" tvg-logo="https://static.epg.best/tr/ATV.tr.png" tvg-chno="421" channel-id="421",atv avrupa HD
 rtp://239.186.84.24:10000
-#EXTINF:-1 tvg-id="Showmax.tr" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
 rtp://239.186.84.36:10000
-#EXTINF:-1 tvg-id="TGRTEU.tr" tvg-name="TGRTEU TR" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="602" tvg-name="TGRTEU TR" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT Turk HD
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT Turk HD
 rtp://239.186.70.210:10000
-#EXTINF:-1 tvg-id="TRTBELGESEL.tr" tvg-name="TRT BELGESEL TR" tvg-logo="https://static.epg.best/tr/TRTBELGESEL.tr.png" tvg-chno="146" channel-id="146",TRT Belgesel HD
+#EXTINF:-1 tvg-id="TRTBelgesel.tr@SD" tvg-name="TRT BELGESEL TR" tvg-logo="https://static.epg.best/tr/TRTBELGESEL.tr.png" tvg-chno="146" channel-id="146",TRT Belgesel HD
 rtp://239.186.70.186:10000
-#EXTINF:-1 tvg-id="TRTCOCUK.tr" tvg-name="TRT COCUK TR" tvg-logo="https://static.epg.best/tr/TRTCOCUK.tr.png" tvg-chno="147" channel-id="147",TRT COCUK HD
+#EXTINF:-1 tvg-id="TRTCocuk.tr@SD" tvg-name="TRT COCUK TR" tvg-logo="https://static.epg.best/tr/TRTCOCUK.tr.png" tvg-chno="147" channel-id="147",TRT COCUK HD
 rtp://239.186.70.185:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI HD
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI HD
 rtp://239.186.84.14:10000
-#EXTINF:-1 tvg-id="TRTSPOR.tr" tvg-name="TRT SPOR TR" tvg-logo="https://static.epg.best/tr/TRTSPOR.tr.png" tvg-chno="148" channel-id="148",TRT SPOR HD
+#EXTINF:-1 tvg-id="TRTSpor.tr@SD" tvg-name="TRT SPOR TR" tvg-logo="https://static.epg.best/tr/TRTSPOR.tr.png" tvg-chno="148" channel-id="148",TRT SPOR HD
 rtp://239.186.70.187:10000
-#EXTINF:-1 tvg-id="TRTmusik.tr" tvg-name="TRT musik TR" tvg-logo="https://static.epg.best/tr/TRTMUSIK.tr.png" tvg-chno="149" channel-id="149",TRT musik HD
+#EXTINF:-1 tvg-id="TRTMuzik.tr@SD" tvg-name="TRT musik TR" tvg-logo="https://static.epg.best/tr/TRTMUSIK.tr.png" tvg-chno="149" channel-id="149",TRT musik HD
 rtp://239.186.70.198:10000
-#EXTINF:-1 tvg-id="CNNTurk.tr" tvg-name="CNNTurk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
+#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNNTurk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
 rtp://239.186.74.75:10000
-#EXTINF:-1 tvg-id="TV8int.tr" tvg-name="TV8int TR" tvg-logo="https://static.epg.best/tr/TV8int.tr.png" tvg-chno="" channel-id="",TV8int HD (tur)
+#EXTINF:-1 tvg-id="TV8int.tr@SD" tvg-name="TV8int TR" tvg-logo="https://static.epg.best/tr/TV8int.tr.png" tvg-chno="" channel-id="",TV8int HD (tur)
 rtp://239.186.70.44:10000
 #EXTREM:others foreign language not listed above
-#EXTINF:-1 tvg-id="DunaTV.hu" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA HD
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA HD
 rtp://239.186.70.205:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD HD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD HD
 rtp://239.186.68.47:10000
-#EXTINF:-1 tvg-id="M1.hu" tvg-name="M1 HU" tvg-logo="https://static.epg.best/hu/M1.hu.png" tvg-chno="156" channel-id="156",M1 HD
+#EXTINF:-1 tvg-id="M1.hu@SD" tvg-name="M1 HU" tvg-logo="https://static.epg.best/hu/M1.hu.png" tvg-chno="156" channel-id="156",M1 HD
 rtp://239.186.70.206:10000
-#EXTINF:-1 tvg-id="M2.hu" tvg-name="M2 HU" tvg-logo="https://static.epg.best/hu/M2.hu.png" tvg-chno="157" channel-id="157",M2 HD
+#EXTINF:-1 tvg-id="M2.hu@SD" tvg-name="M2 HU" tvg-logo="https://static.epg.best/hu/M2.hu.png" tvg-chno="157" channel-id="157",M2 HD
 rtp://239.186.70.207:10000
-#EXTINF:-1 tvg-id="M5.hu" tvg-name="M5 HU" tvg-logo="https://static.epg.best/hu/M5.hu.png" tvg-chno="159" channel-id="159",M5 HD
+#EXTINF:-1 tvg-id="M5.hu@SD" tvg-name="M5 HU" tvg-logo="https://static.epg.best/hu/M5.hu.png" tvg-chno="159" channel-id="159",M5 HD
 rtp://239.186.70.209:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA HD
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA HD
 rtp://239.186.84.96:10000
-#EXTINF:-1 tvg-id="TVPinfo.pl" tvg-name="TVP info PL" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
+#EXTINF:-1 tvg-id="2066" tvg-name="TVP info PL" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
 rtp://239.186.84.151:10000
-#EXTINF:-1 tvg-id="EpicDrama.pl" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
+#EXTINF:-1 tvg-id="902" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
 rtp://239.186.70.99:10000
-#EXTINF:-1 ,YKPAÏHA 24 / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="1919" ,YKPAÏHA 24 / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 ,Espreso TV HD (ukr)
 rtp://239.186.84.176:10000
-#EXTINF:-1 tvg-id="2MMonde.ma" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="tunisienationale.tn" tvg-name="Tunisie Nationale TN" tvg-logo="https://static.epg.best/tn/tunisienationale.tn.png" tvg-chno="153" channel-id="153",Tunisie Nationale
+#EXTINF:-1 tvg-id="ElWatania1.tn@SD" tvg-name="Tunisie Nationale TN" tvg-logo="https://static.epg.best/tn/tunisienationale.tn.png" tvg-chno="153" channel-id="153",Tunisie Nationale
 rtp://239.186.74.89:10000
-#EXTINF:-1 tvg-id="BVN.nl" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
 rtp://239.186.70.89:10000
-#EXTINF:-1 tvg-id="DMsat.sr" tvg-name="DM SAT SR" tvg-logo="https://static.epg.best/sr/DMsat.sr.png" tvg-chno="439" channel-id="439",DM Sat
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="DM SAT SR" tvg-logo="https://static.epg.best/sr/DMsat.sr.png" tvg-chno="439" channel-id="439",DM Sat
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",Dubai international TV HD
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",Dubai international TV HD
 rtp://239.186.70.246:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
 rtp://239.186.70.80:10000
-#EXTINF:-1 tvg-id="HRT1.hr" tvg-name="HRT1 HR" tvg-logo="https://static.epg.best/hr/HRT1.hr" tvg-chno="446" channel-id="446",HRT1 HD
+#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT1 HR" tvg-logo="https://static.epg.best/hr/HRT1.hr" tvg-chno="446" channel-id="446",HRT1 HD
 rtp://239.186.70.183:10000
-#EXTINF:-1 tvg-id="HRTint.hr" tvg-name="HRTint HR" tvg-logo="https://static.epg.best/hr/HRTint.hr" tvg-chno="446" channel-id="446",HRT int HD
+#EXTINF:-1 tvg-id="HRTInternational.hr@SD" tvg-name="HRTint HR" tvg-logo="https://static.epg.best/hr/HRTint.hr" tvg-chno="446" channel-id="446",HRT int HD
 rtp://239.186.70.153:10000
-#EXTINF:-1 tvg-id="HRT4.hr" tvg-name="HRT4 HR" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
+#EXTINF:-1 tvg-id="2069" tvg-name="HRT4 HR" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
 rtp://239.186.84.145:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="https://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="Kurdistantv.iq" tvg-name="KurdistanTV IQ" tvg-logo="https://static.epg.best/iq/Kurdistantv.iq.png" tvg-chno="449" channel-id="449",Kurdistan TV
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="KurdistanTV IQ" tvg-logo="https://static.epg.best/iq/Kurdistantv.iq.png" tvg-chno="449" channel-id="449",Kurdistan TV
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="phoenixnews.cn" tvg-name="phoenix news CN" tvg-logo="https://static.epg.best/cn/phoenixnews.cn.png" tvg-chno="451" channel-id="451",PHOENIX NEWS Taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="phoenix news CN" tvg-logo="https://static.epg.best/cn/phoenixnews.cn.png" tvg-chno="451" channel-id="451",PHOENIX NEWS Taiwan
 rtp://239.186.66.132:10000
-#EXTINF:-1 tvg-id="RTRplaneta.ru" tvg-name="RTRPlaneta RU" tvg-logo="https://static.epg.best/ru/rtrplaneta.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
+#EXTINF:-1 tvg-id="RTRPlanetaEurope.ru@SD" tvg-name="RTRPlaneta RU" tvg-logo="https://static.epg.best/ru/rtrplaneta.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
-#EXTINF:-1 tvg-id="RTK.al" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",Rudaw TV HD (kur)
+#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",Rudaw TV HD (kur)
 rtp://239.186.68.247:10000
-#EXTINF:-1 tvg-id="ProTV.ro" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV
 rtp://239.186.66.135:10000
-#EXTINF:-1 tvg-id="tvri.ro" tvg-name="TVRomania RO" tvg-logo="https://static.epg.best/ro/tvri.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="TVRomania RO" tvg-logo="https://static.epg.best/ro/tvri.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
 #EXTINF:-1 tvg-id="ptccbet.rs" tvg-name="PTC CBET RS" tvg-logo="https://static.epg.best/rs/ptccbet.rs.png" tvg-chno="473" channel-id="473",PTC CBET HD
 rtp://239.186.70.164:10000
-#EXTINF:-1 tvg-id="KBSWorld.kr" tvg-name="KBS World KR" tvg-logo="https://static.epg.best/kr/KBSWorld.kr.png" tvg-chno="160" channel-id="160",KBS World HD
+#EXTINF:-1 tvg-id="KBSWorld.kr@SD" tvg-name="KBS World KR" tvg-logo="https://static.epg.best/kr/KBSWorld.kr.png" tvg-chno="160" channel-id="160",KBS World HD
 rtp://239.186.70.191:10000
-#EXTINF:-1 tvg-id="CT24.cz" tvg-name="CT24 CZ" tvg-logo="https://static.epg.best/cz/CT24.cz.png" tvg-chno="" channel-id="",CT24 HD
+#EXTINF:-1 tvg-id="CT24.cz@SD" tvg-name="CT24 CZ" tvg-logo="https://static.epg.best/cz/CT24.cz.png" tvg-chno="" channel-id="",CT24 HD
 rtp://239.186.70.18:10000
-#EXTINF:-1 tvg-id="Alarabiya.sa" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al arabiya HD (ara)
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al arabiya HD (ara)
 rtp://239.186.84.11:10000
-#EXTINF:-1 ,bn music HD (bos)
+#EXTINF:-1 tvg-id="BNMusic.ba@SD" ,bn music HD (bos)
 rtp://239.186.84.34:10000
-#EXTINF:-1 ,TV Duga+ (bos)
+#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD" ,TV Duga+ (bos)
 rtp://239.186.74.77:10000
-#EXTINF:-1 ,Diaspora Swiss TV HD
+#EXTINF:-1 tvg-id="OraTV.al@SD" ,Diaspora Swiss TV HD
 rtp://239.186.84.107:10000
 #EXTINF:-1 tvg-id="Adria.si" tvg-name="Adria SI" tvg-logo="https://static.epg.best/si/adria.si.png" tvg-chno="" channel-id="",ADRIA Music Television HD (svn)
 rtp://239.186.68.184:10000
-#EXTINF:-1 tvg-id="AlMasriya.eg" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasria.eg.png" tvg-chno="" channel-id="",Al Masriya HD (ara)
+#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasria.eg.png" tvg-chno="" channel-id="",Al Masriya HD (ara)
 rtp://239.186.70.13:10000
-#EXTINF:-1 ,TOP NEWS HD (alb)
+#EXTINF:-1 tvg-id="614" ,TOP NEWS HD (alb)
 rtp://239.186.84.144:10000
-#EXTINF:-1 ,rtv24 (slo)
+#EXTINF:-1 tvg-id="1910" ,rtv24 (slo)
 rtp://239.186.84.149:10000
 #EXTINF:-1 ,mne HD (srp)
 rtp://239.186.84.154:10000
-#EXTINF:-1 ,RTSH24 HD (alb)
+#EXTINF:-1 tvg-id="RTS2.ch@SD" ,RTSH24 HD (alb)
 rtp://239.186.84.155:10000
 #EXTINF:-1 ,nikceabtv HD (ukr)
 rtp://239.186.84.161:10000
 #EXTINF:-1 ,ENTER FILM HD (ukr)
 rtp://239.186.84.163:10000
-#EXTINF:-1 ,n HD (ukr)
+#EXTINF:-1 tvg-id="ntv.de@SD" ,n HD (ukr)
 rtp://239.186.84.167:10000
 #EXTINF:-1 ,BOYAH HD (ell)
 rtp://239.186.84.170:10000
-#EXTINF:-1 ,RTVI (rus)
+#EXTINF:-1 tvg-id="371" ,RTVI (rus)
 rtp://239.186.74.2:10000
-#EXTINF:-1,Info Channel HD
+#EXTINF:-1tvg-id="1727" ,Info Channel HD
 rtp://239.186.70.168:10000

--- a/swisscom-hd.m3u
+++ b/swisscom-hd.m3u
@@ -37,9 +37,9 @@ rtp://239.186.70.30:10000
 rtp://239.186.70.29:10000
 #EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="24" channel-id="24",6ter HD
 rtp://239.186.68.134:10000
-#EXTINF:-1 tvg-id="LCI.fr@SD" tvg-name="La Chaine Info" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
+#EXTINF:-1 tvg-id="LCI.fr@SD" tvg-name="La Chaine Info - LCI" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
 rtp://239.186.68.241:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBSM" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
 rtp://239.186.70.41:10000
 #EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="31" channel-id="31",TV5 MONDE EUROPE HD
 rtp://239.186.84.54:10000
@@ -59,7 +59,7 @@ rtp://239.186.70.148:10000
 rtp://239.186.70.125:10000
 #EXTINF:-1 tvg-id="i24NEWSFrench.il@SD" tvg-name="i24 News Français" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
-#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="Grand Genève TV" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="ici TV Romandie" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
 rtp://239.186.70.133:10000
 #EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
@@ -107,11 +107,11 @@ rtp://239.186.68.135:10000
 rtp://239.186.68.132:10000
 #EXTINF:-1 tvg-id="tvmonaco.fr" tvg-name="tvmonaco FR" tvg-logo="https://static.epg.best/fr/tvmonaco.fr.png" tvg-chno="" channel-id="",TV Monaco HD
 rtp://239.186.68.167:10000
-#EXTINF:-1 tvg-id="t18.fr" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
+#EXTINF:-1 tvg-id="t18.fr" tvg-name="T18" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
 rtp://239.186.70.24:10000
 #EXTINF:-1 tvg-id="canalbfr.ch" tvg-name="canalbfr CH" tvg-logo="https://static.epg.best/ch/canalbfr.ch.png" tvg-chno="" channel-id="",Canalb fr HD
 rtp://239.186.70.174:10000
-#EXTINF:-1 tvg-id="novo19.fr" tvg-name="NOVO19 FR" tvg-logo="https://static.epg.best/fr/novo19.fr.png" tvg-chno="" channel-id="",NOVO19 HD
+#EXTINF:-1 tvg-id="novo19.fr" tvg-name="Novo 19" tvg-logo="https://static.epg.best/fr/novo19.fr.png" tvg-chno="" channel-id="",NOVO19 HD
 rtp://239.186.70.167:10000
 #EXTREM:english
 #EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBC1.uk.png" tvg-chno="90" channel-id="90",BBC ONE HD
@@ -170,7 +170,7 @@ rtp://239.186.70.150:10000
 rtp://239.186.70.245:10000
 #EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More 4" tvg-logo="https://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World Japan" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
 rtp://239.186.68.172:10000
 #EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News International" tvg-logo="https://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky NEWS international
 rtp://239.186.64.179:10000
@@ -198,7 +198,7 @@ rtp://239.186.74.74:10000
 rtp://239.186.74.87:10000
 #EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Pick" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
+#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Sky Mix" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
 rtp://239.186.84.95:10000
 #EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
@@ -208,9 +208,9 @@ rtp://239.186.74.108:10000
 rtp://239.186.74.106:10000
 #EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s" tvg-logo="https://static.epg.best/gb/NowRocks.uk.png" tvg-chno="" channel-id="",Now Rock
 rtp://239.186.66.133:10000
-#EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/Greatmystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
+#EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery" tvg-logo="https://static.epg.best/gb/Greatmystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
-#EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/TrueCrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME
+#EXTINF:-1 tvg-id="CBSRealityEMEA.uk@SD" tvg-name="True Crime" tvg-logo="https://static.epg.best/gb/TrueCrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME
 rtp://239.186.74.107:10000
 #EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance" tvg-logo="https://static.epg.best/gb/GreatClassic.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
@@ -218,9 +218,9 @@ rtp://239.186.74.53:10000
 rtp://239.186.74.58:10000
 #EXTINF:-1 tvg-id="GBNews.uk@SD" tvg-name="GB News" tvg-logo="https://static.epg.best/uk/GBNews.uk.png" tvg-chno="" channel-id="",GB News HD
 rtp://239.186.84.57:10000
-#EXTINF:-1 tvg-id=""  tvg-name="EU Parlament+",EU Parliament+ HD
+#EXTINF:-1 tvg-id=""  tvg-name="EU Parliament+",EU Parliament+ HD
 rtp://239.186.84.42:10000
-#EXTINF:-1 tvg-id=""  tvg-name="EU Parlament",EU Parliament HD
+#EXTINF:-1 tvg-id=""  tvg-name="EU Parliament",EU Parliament HD
 rtp://239.186.84.45:10000
 #EXTINF:-1 tvg-id=""  tvg-name="CGTN Documentary",CGTN DOCUMENTARY HD
 rtp://239.186.84.147:10000
@@ -447,7 +447,7 @@ rtp://239.186.84.60:10000
 rtp://239.186.84.80:10000
 #EXTINF:-1 tvg-id="ArcadiaTV.li@SD" tvg-name="ARCADIA world TV" tvg-logo="https://static.epg.best/ro/ArcadiaTV.ro.png" tvg-chno="" channel-id="" ,ARCADIA WORLD TV HD
 rtp://239.186.84.1:10000
-#EXTINF:-1 ,DMF HD
+#EXTINF:-1  tvg-name="DMF" tvg-id="DMF.de@SD",DMF HD
 rtp://239.186.70.96:10000
 #EXTINF:-1 tvg-id=""  tvg-name="Stimmungsgarten TV",stimmungsgarten.tv
 rtp://239.186.74.148:10000
@@ -455,11 +455,11 @@ rtp://239.186.74.148:10000
 rtp://239.186.74.150:10000
 #EXTINF:-1 tvg-id="TVRheintal.ch@SD"  tvg-name="TV Rheintal",TV RT HD (deu) TV   TV Rheintal HD
 rtp://239.186.84.171:10000
-#EXTINF:-1 ,I-TV HD
+#EXTINF:-1  tvg-name="I-TV",I-TV HD
 rtp://239.186.70.91:10000
 #EXTINF:-1 ,just.fishing (deu)
 rtp://239.186.74.157:10000
-#EXTINF:-1 ,SYLT1 HD
+#EXTINF:-1  tvg-name="SYLT1",SYLT1 HD
 rtp://239.186.70.126:10000
 #EXTINF:-1 ,DF1 HD (deu)
 rtp://239.186.68.93:10000
@@ -469,14 +469,14 @@ rtp://239.186.68.53:10000
 rtp://239.186.70.140:10000
 #EXTINF:-1tvg-id="LiloTV.de@SD"  tvg-name="Lilo TV",lilo TV
 rtp://239.186.74.82:10000
-#EXTINF:-1tvg-id="" ,network tv HD
+#EXTINF:-1tvg-id=""  tvg-name="Network-TV",network tv HD
 rtp://239.186.84.173:10000
 #EXTINF:-1 tvg-id="" tvg-name="ntv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="340" channel-id="",ntv
 rtp://239.186.64.29:10000
 #EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="https://static.epg.best/ch/canalbde.ch.png" tvg-chno="" channel-id="",Canalb de HD
 rtp://239.186.70.173:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
 rtp://239.186.76.24:10000
 #EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 FHD
 rtp://239.186.76.25:10000
@@ -504,7 +504,7 @@ rtp://239.186.70.233:10000
 rtp://239.186.84.89:10000
 #EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros. Discovery Giallo HD
 rtp://239.186.84.99:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Discovery Turbo" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
 rtp://239.186.84.102:10000
 #EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros. Discovery food network I HD
 rtp://239.186.84.91:10000
@@ -632,7 +632,7 @@ rtp://239.186.84.156:10000
 rtp://239.186.84.178:10000
 #EXTINF:-1, Radio24 tv Il Sole 24 ORE HD
 rtp://239.186.70.33:10000
-#EXTINF:-1,wedotv Movies IT HD (ita)
+#EXTINF:-1 tvg-name="wedotv Movies IT",wedotv Movies IT HD (ita)
 rtp://239.186.70.169:10000
 #EXTREM:portuguese
 #EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
@@ -665,7 +665,7 @@ rtp://239.186.70.184:10000
 rtp://239.186.84.24:10000
 #EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show Türk" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
 rtp://239.186.84.36:10000
 #EXTINF:-1 tvg-id="TGRTEU.tr" tvg-name="TGRT EU" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
@@ -704,7 +704,7 @@ rtp://239.186.84.151:10000
 rtp://239.186.70.99:10000
 #EXTINF:-1 tvg-id="" tvg-name="FreeDOM",YKPAÏHA 24 / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
-#EXTINF:-1 tvg-id="EspresoTV.ua@SD",Espreso TV HD (ukr)
+#EXTINF:-1 tvg-id="EspresoTV.ua@SD" tvg-name="Espreso TV",Espreso TV HD (ukr)
 rtp://239.186.84.176:10000
 #EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
 rtp://239.186.64.194:10000
@@ -718,7 +718,7 @@ rtp://239.186.70.89:10000
 rtp://239.186.64.79:10000
 #EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",Dubai international TV HD
 rtp://239.186.70.246:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT Cosmos" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
 rtp://239.186.70.80:10000
 #EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT 1" tvg-logo="https://static.epg.best/hr/HRT1.hr" tvg-chno="446" channel-id="446",HRT1 HD
 rtp://239.186.70.183:10000
@@ -734,7 +734,7 @@ rtp://239.186.66.203:10000
 rtp://239.186.66.132:10000
 #EXTINF:-1 tvg-id="RTRPlanetaEurope.ru@SD" tvg-name="RTR Planeta" tvg-logo="https://static.epg.best/ru/rtrplaneta.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK 1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
 rtp://239.186.64.81:10000
 #EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="Rudaw TV" tvg-logo="" tvg-chno="460" channel-id="460",Rudaw TV HD (kur)
 rtp://239.186.68.247:10000
@@ -770,7 +770,7 @@ rtp://239.186.84.154:10000
 rtp://239.186.84.155:10000
 #EXTINF:-1 ,nikceabtv HD (ukr)
 rtp://239.186.84.161:10000
-#EXTINF:-1 ,ENTER FILM HD (ukr)
+#EXTINF:-1  tvg-name="Enter-Film",ENTER FILM HD (ukr)
 rtp://239.186.84.163:10000
 #EXTINF:-1 tvg-id="ntv.de@SD"  tvg-name="n-tv",n HD (ukr)
 rtp://239.186.84.167:10000
@@ -778,5 +778,5 @@ rtp://239.186.84.167:10000
 rtp://239.186.84.170:10000
 #EXTINF:-1 tvg-id=""  tvg-name="RTVi",RTVI (rus)
 rtp://239.186.74.2:10000
-#EXTINF:-1tvg-id="" ,Info Channel HD
+#EXTINF:-1tvg-id=""  tvg-name="Info Channel",Info Channel HD
 rtp://239.186.70.168:10000

--- a/swisscom-hd.m3u
+++ b/swisscom-hd.m3u
@@ -1,9 +1,9 @@
 #EXTM3U 
 #PLAYLIST: blue tv open channels
 #EXTREM:french
-#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS Un" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="1" channel-id="1",RTS1 FHD
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS 1" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="1" channel-id="1",RTS1 FHD
 rtp://239.186.76.26:10000
-#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS Deux" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="2" channel-id="2",RTS2 FHD
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS 2" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="2" channel-id="2",RTS2 FHD
 rtp://239.186.76.27:10000
 #EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="3" channel-id="3",TF1 CH HD
 rtp://239.186.68.21:10000
@@ -17,7 +17,7 @@ rtp://239.186.84.55:10000
 rtp://239.186.70.27:10000
 #EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="8" channel-id="8",M6 CH HD
 rtp://239.186.68.20:10000
-#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="9" channel-id="9",arte F HD
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte Français" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="9" channel-id="9",arte F HD
 rtp://239.186.68.18:10000
 #EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="11" channel-id="11",W9 CH HD
 rtp://239.186.70.38:10000
@@ -25,295 +25,295 @@ rtp://239.186.70.38:10000
 rtp://239.186.70.37:10000
 #EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="13" channel-id="13",TFX CH HD
 rtp://239.186.70.34:10000
-#EXTINF:-1 tvg-id="LCP.fr@SD" tvg-name="LCP Public Sénat" tvg-logo="https://static.epg.best/fr/LaChaineParlementaire.fr.png" tvg-chno="15" channel-id="15",LCP8 Public Sénat HD
+#EXTINF:-1 tvg-id="LCP.fr@SD" tvg-name="La Chaîne parlementaire" tvg-logo="https://static.epg.best/fr/LaChaineParlementaire.fr.png" tvg-chno="15" channel-id="15",LCP8 Public Sénat HD
 rtp://239.186.84.35:10000
-#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo:" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="29" channel-id="29",franceinfo HD
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="29" channel-id="29",franceinfo HD
 rtp://239.186.70.121:10000
 #EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="17" channel-id="17",BFMTV CH HD
 rtp://239.186.68.196:10000
-#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="18" channel-id="18",CNEWS HD
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNEWS" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="18" channel-id="18",CNEWS HD
 rtp://239.186.70.30:10000
 #EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="20" channel-id="20",gulli HD
 rtp://239.186.70.29:10000
 #EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="24" channel-id="24",6ter HD
 rtp://239.186.68.134:10000
-#EXTINF:-1 tvg-id="LCI.fr@SD" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
+#EXTINF:-1 tvg-id="LCI.fr@SD" tvg-name="La Chaine Info" tvg-logo="https://static.epg.best/fr/lci.fr.png" tvg-chno="28" channel-id="28",LCI HD La Chaine Info HD
 rtp://239.186.68.241:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5MONDE France Belgique Suisse Monaco" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="https://static.epg.best/fr/TV5MondeFBSM.fr.png" tvg-chno="30" channel-id="30",TV5 MONDE FBSM HD
 rtp://239.186.70.41:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="31" channel-id="31",TV5 MONDE EUROPE HD
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="31" channel-id="31",TV5 MONDE EUROPE HD
 rtp://239.186.84.54:10000
-#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="32" channel-id="32",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="32" channel-id="32",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="75" channel-id="75",8 Mont-Blanc HD
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="75" channel-id="75",8 Mont-Blanc HD
 rtp://239.186.70.106:10000
-#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal9.ch" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="77" channel-id="77",Canal9 HD
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal 9" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="77" channel-id="77",Canal9 HD
 rtp://239.186.68.144:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="78" channel-id="78",CanalAlpha JU HD
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="78" channel-id="78",CanalAlpha JU HD
 rtp://239.186.68.193:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="79" channel-id="79",Canal Alpha NE HD
+#EXTINF:-1 tvg-id="CanalAlphaNE.ch@SD" tvg-name="Canal Alpha NE" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="79" channel-id="79",Canal Alpha NE HD
 rtp://239.186.68.194:10000
-#EXTINF:-1 tvg-id="EuronewsFrench.fr@SD" tvg-name="Euronews" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="80" channel-id="80",euronews. F HD
+#EXTINF:-1 tvg-id="EuronewsFrench.fr@SD" tvg-name="Euronews F" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="80" channel-id="80",euronews. F HD
 rtp://239.186.70.148:10000
 #EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="https://static.epg.best/fr/France24f.fr.png" tvg-chno="63" channel-id="63",France24 HD
 rtp://239.186.70.125:10000
-#EXTINF:-1 tvg-id="i24NEWSFrench.il@SD" tvg-name="" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
+#EXTINF:-1 tvg-id="i24NEWSFrench.il@SD" tvg-name="i24 News Français" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
-#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="icitv CH" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="Grand Genève TV" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
 rtp://239.186.70.133:10000
-#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
-#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="303" channel-id="303",TeleBielingue HD
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="Tele Bielingue" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="303" channel-id="303",TeleBielingue HD
 rtp://239.186.70.82:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",leman bleu HD
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Léman Bleu Télévision" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="76" channel-id="76",leman bleu HD
 rtp://239.186.70.39:10000
-#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="84" channel-id="84",carac1 HD (ex rouge TV HD)
+#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="CARAC 1" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="84" channel-id="84",carac1 HD (ex rouge TV HD)
 rtp://239.186.68.253:10000
-#EXTINF:-1 tvg-id="OneTV.ch@SD" tvg-name="carac2 CH" tvg-logo="https://static.epg.best/ch/carac2.ch.png" tvg-chno="83" channel-id="83",carac2 HD (ex one tv HD)
+#EXTINF:-1 tvg-id="OneTV.ch@SD" tvg-name="CARAC 2" tvg-logo="https://static.epg.best/ch/carac2.ch.png" tvg-chno="83" channel-id="83",carac2 HD (ex one tv HD)
 rtp://239.186.70.12:10000
-#EXTINF:-1 tvg-id="LFMTV.ch@SD" tvg-name="carac3 CH" tvg-logo="https://static.epg.best/ch/carac3.ch.png" tvg-chno="77" channel-id="77",carac3 HD (ex lfm TV HD)
+#EXTINF:-1 tvg-id="LFMTV.ch@SD" tvg-name="CARAC 3" tvg-logo="https://static.epg.best/ch/carac3.ch.png" tvg-chno="77" channel-id="77",carac3 HD (ex lfm TV HD)
 rtp://239.186.70.11:10000
-#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="79" channel-id="79",carac4 HD (ex TV SUISSE PLUS HD)
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="CARAC 4" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="79" channel-id="79",carac4 HD (ex TV SUISSE PLUS HD)
 rtp://239.186.70.104:10000
-#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac5 CH" tvg-logo="https://static.epg.best/ch/teleswizz.ch.png" tvg-chno="74" channel-id="74",carac5 HD (ex TeleSwizz HD)
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="CARAC 4" tvg-logo="https://static.epg.best/ch/teleswizz.ch.png" tvg-chno="74" channel-id="74",carac5 HD (ex TeleSwizz HD)
 rtp://239.186.68.208:10000
-#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/tvm3.ch.png" tvg-chno="80" channel-id="80",tvm3 HD
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="https://static.epg.best/ch/tvm3.ch.png" tvg-chno="80" channel-id="80",tvm3 HD
 rtp://239.186.70.21:10000
-#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="MaxTV CH" tvg-logo="https://static.epg.best/ch/maxtv.ch.png" tvg-chno="81" channel-id="81",maxtv HD/DieuTV HD
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="Max TV" tvg-logo="https://static.epg.best/ch/maxtv.ch.png" tvg-chno="81" channel-id="81",maxtv HD/DieuTV HD
 rtp://239.186.68.199:10000
-#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV CH" tvg-logo="https://static.epg.best/ch/nrtv.ch.png" tvg-chno="82" channel-id="82",nrtv HD
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV" tvg-logo="https://static.epg.best/ch/nrtv.ch.png" tvg-chno="82" channel-id="82",nrtv HD
 rtp://239.186.70.66:10000
-#EXTINF:-1 tvg-id="371" tvg-name="GRTV CH" tvg-logo="https://static.epg.best/ch/grtv.ch.png" tvg-chno="85" channel-id="85",GRTV / TéléVersoix HD
+#EXTINF:-1 tvg-id="" tvg-name="GRTV CH" tvg-logo="https://static.epg.best/ch/grtv.ch.png" tvg-chno="85" channel-id="85",GRTV / TéléVersoix HD
 rtp://239.186.70.155:10000
-#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="TV Onex CH" tvg-logo="https://static.epg.best/ch/tvonex.ch.png" tvg-chno="86" channel-id="86",TV Onex HD
+#EXTINF:-1 tvg-id="TVOnex.ch@SD" tvg-name="TV Onex" tvg-logo="https://static.epg.best/ch/tvonex.ch.png" tvg-chno="86" channel-id="86",TV Onex HD
 rtp://239.186.70.132:10000
 #EXTINF:-1 ,Rhone TV HD
 rtp://239.186.84.172:10000
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="89" channel-id="89",blue ZOOM F HD
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="89" channel-id="89",blue ZOOM F HD
 rtp://239.186.68.244:10000
 #EXTINF:-1 tvg-id="SRTB.bj" tvg-name="SRTB BJ" tvg-logo="https://static.epg.best/bj/SRTB.bj.png" tvg-chno="90" channel-id="90",SRTB BENIN TV
 rtp://239.186.74.97:10000
-#EXTINF:-1 tvg-id="TF1SeriesFilms.fr@SD" tvg-name="TF1 Séries Films FR" tvg-logo="https://static.epg.best/fr/TF1SeriesFilms.fr.png" tvg-chno="25" channel-id="25",TF1 Series Films HD
+#EXTINF:-1 tvg-id="TF1SeriesFilms.fr@SD" tvg-name="TF1 Séries Films" tvg-logo="https://static.epg.best/fr/TF1SeriesFilms.fr.png" tvg-chno="25" channel-id="25",TF1 Series Films HD
 rtp://239.186.68.133:10000
-#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Life FR" tvg-logo="https://static.epg.best/fr/rmclife.fr.png" tvg-chno="27" channel-id="27",RMC Life HD
+#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Story" tvg-logo="https://static.epg.best/fr/rmclife.fr.png" tvg-chno="27" channel-id="27",RMC Life HD
 rtp://239.186.68.131:10000
-#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="35" channel-id="35",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3" tvg-logo="http://static.epg.best/fr/AB3.fr.png" tvg-chno="35" channel-id="35",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="RMCDecouverte.fr@SD" tvg-name="RMC Découverte FR" tvg-logo="https://static.epg.best/fr/RMCdecouverte.fr.png" tvg-chno="26" channel-id="26",RMC Decouvertes HD
+#EXTINF:-1 tvg-id="RMCDecouverte.fr@SD" tvg-name="RMC Découverte" tvg-logo="https://static.epg.best/fr/RMCdecouverte.fr.png" tvg-chno="26" channel-id="26",RMC Decouvertes HD
 rtp://239.186.68.130:10000
-#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Story FR" tvg-logo="https://static.epg.best/fr/RMCStory.fr.png" tvg-chno="22" channel-id="22",RMC Story HD
+#EXTINF:-1 tvg-id="RMCStory.fr@SD" tvg-name="RMC Story" tvg-logo="https://static.epg.best/fr/RMCStory.fr.png" tvg-chno="22" channel-id="22",RMC Story HD
 rtp://239.186.68.135:10000
-#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="LEquipe21" tvg-logo="https://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="23" channel-id="23",La chaine L'EQUIPE HD
+#EXTINF:-1 tvg-id="LEquipe.fr@SD" tvg-name="L'Equipe" tvg-logo="https://static.epg.best/fr/LEquipe21.fr.png" tvg-chno="23" channel-id="23",La chaine L'EQUIPE HD
 rtp://239.186.68.132:10000
 #EXTINF:-1 tvg-id="tvmonaco.fr" tvg-name="tvmonaco FR" tvg-logo="https://static.epg.best/fr/tvmonaco.fr.png" tvg-chno="" channel-id="",TV Monaco HD
 rtp://239.186.68.167:10000
-#EXTINF:-1 tvg-id="495" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
+#EXTINF:-1 tvg-id="" tvg-name="T18 FR" tvg-logo="https://static.epg.best/fr/t18.fr.png" tvg-chno="" channel-id="",T18 HD
 rtp://239.186.70.24:10000
 #EXTINF:-1 tvg-id="canalbfr.ch" tvg-name="canalbfr CH" tvg-logo="https://static.epg.best/ch/canalbfr.ch.png" tvg-chno="" channel-id="",Canalb fr HD
 rtp://239.186.70.174:10000
 #EXTINF:-1 tvg-id="novo19.fr" tvg-name="NOVO19 FR" tvg-logo="https://static.epg.best/fr/novo19.fr.png" tvg-chno="" channel-id="",NOVO19 HD
 rtp://239.186.70.167:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/uk/BBC1.uk.png" tvg-chno="90" channel-id="90",BBC ONE HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBC1.uk.png" tvg-chno="90" channel-id="90",BBC ONE HD
 rtp://239.186.68.43:10000
-#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/uk/BBC2.uk.png" tvg-chno="91" channel-id="91",BBC TWO HD
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC Two" tvg-logo="https://static.epg.best/uk/BBC2.uk.png" tvg-chno="91" channel-id="91",BBC TWO HD
 rtp://239.186.68.41:10000
-#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/uk/CBBC.uk.png" tvg-chno="92" channel-id="92",BBC THREE HD / CBBC HD
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="https://static.epg.best/uk/CBBC.uk.png" tvg-chno="92" channel-id="92",BBC THREE HD / CBBC HD
 rtp://239.186.68.153:10000
-#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
+#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/uk/BBC4.uk.png" tvg-chno="93" channel-id="93",BBC FOUR HD / BBC CBeebies HD
 rtp://239.186.68.158:10000
-#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/uk/CBeebies.uk.png" tvg-chno="94" channel-id="94",BBC CBeebies HD / BBC FOUR HD
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="https://static.epg.best/uk/CBeebies.uk.png" tvg-chno="94" channel-id="94",BBC CBeebies HD / BBC FOUR HD
 rtp://239.186.68.152:10000
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (UK) HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (UK) HD
 rtp://239.186.68.160:10000
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC News UK" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/uk/BBCNews.uk.png" tvg-chno="95" channel-id="95",BBC NEWS (Europe) HD
 rtp://239.186.68.214:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament UK" tvg-logo="https://static.epg.best/uk/BBCParliament.uk.png" tvg-chno="97" channel-id="97",BBC PARLIAMENT HD
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament" tvg-logo="https://static.epg.best/uk/BBCParliament.uk.png" tvg-chno="97" channel-id="97",BBC PARLIAMENT HD
 rtp://239.186.70.65:10000
-#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="98" channel-id="98",Bloomberg TV UK HD
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV" tvg-logo="https://static.epg.best/uk/BloombergTV.uk.png" tvg-chno="98" channel-id="98",Bloomberg TV UK HD
 rtp://239.186.68.125:10000
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="100" channel-id="100",CGTN E HD
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="100" channel-id="100",CGTN E HD
 rtp://239.186.70.90:10000
-#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/uk/Channel4.uk.png" tvg-chno="101" channel-id="101",Channel4 HD
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4" tvg-logo="https://static.epg.best/uk/Channel4.uk.png" tvg-chno="101" channel-id="101",Channel4 HD
 rtp://239.186.68.40:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="104" channel-id="104",Clubland TV
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV" tvg-logo="https://static.epg.best/uk/ClublandTV.uk.png" tvg-chno="104" channel-id="104",Clubland TV
 rtp://239.186.66.116:10000
 #EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/uk/CNBC.uk.png" tvg-chno="105" channel-id="105",CNBC UK HD
 rtp://239.186.70.224:10000
-#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="https://static.epg.best/uk/CNN.uk.png" tvg-chno="107" channel-id="107",CNN International HD
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN" tvg-logo="https://static.epg.best/uk/CNN.uk.png" tvg-chno="107" channel-id="107",CNN International HD
 rtp://239.186.70.23:10000
-#EXTINF:-1 tvg-id="902" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
+#EXTINF:-1 tvg-id="" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="108" channel-id="108",U&DRAMA
 rtp://239.186.66.140:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="109" channel-id="109",DW English HD
 rtp://239.186.70.249:10000
-#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="https://static.epg.best/uk/E4.uk.png" tvg-chno="110" channel-id="110",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4" tvg-logo="https://static.epg.best/uk/E4.uk.png" tvg-chno="110" channel-id="110",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/uk/EuroNews.uk.png" tvg-chno="111" channel-id="111",euronews E HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/uk/EuroNews.uk.png" tvg-chno="111" channel-id="111",euronews E HD
 rtp://239.186.70.105:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="https://static.epg.best/uk/Film4.uk.png" tvg-chno="113" channel-id="113",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="114" channel-id="114",Channel5 CH HD
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="114" channel-id="114",Channel5 CH HD
 rtp://239.186.70.151:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/uk/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="Digi24.ro@SD" tvg-name="i24 IL" tvg-logo="https://static.epg.best/uk/i24.il.png" tvg-chno="158" channel-id="158",i24 NEWS E HD
+#EXTINF:-1 tvg-id="Digi24.ro@SD" tvg-name="Digi 24" tvg-logo="https://static.epg.best/uk/i24.il.png" tvg-chno="158" channel-id="158",i24 NEWS E HD
 rtp://239.186.68.140:10000
-#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1 UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="160" channel-id="160",itv1 HD
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="160" channel-id="160",itv1 HD
 rtp://239.186.68.42:10000
-#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2 HD
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2 HD
 rtp://239.186.84.16:10000
-#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3 HD
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3 HD
 rtp://239.186.70.189:10000
-#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4 HD
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4 HD
 rtp://239.186.70.150:10000
 #EXTINF:-1 tvg-id="ITVQuiz.uk" tvg-name="ITVQuiz UK" tvg-logo="https://static.epg.best/gb/ITVQuiz.uk.png" tvg-chno="164" channel-id="164",itvQuiz HD
 rtp://239.186.70.245:10000
-#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="https://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More 4" tvg-logo="https://static.epg.best/uk/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World JP" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-name="NHK World" tvg-logo="https://static.epg.best/jp/NHKWorld.jp.png" tvg-chno="168" channel-id="168",NHK World HD
 rtp://239.186.68.172:10000
-#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky NEWS international
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News International" tvg-logo="https://static.epg.best/uk/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky NEWS international
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="https://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="245" channel-id="245",5USA
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA" tvg-logo="https://static.epg.best/uk/FiveUSA.uk.png" tvg-chno="245" channel-id="245",5USA
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/uk/PBSAmerica.uk.png" tvg-chno="137" channel-id="137",PBS America
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America" tvg-logo="https://static.epg.best/uk/PBSAmerica.uk.png" tvg-chno="137" channel-id="137",PBS America
 rtp://239.186.66.243:10000
-#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English QA" tvg-logo="https://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",ALJAZEERA E HD
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-name="Al Jazeera English" tvg-logo="https://static.epg.best/qa/AlJazeeraEnglish.qa.png" tvg-chno="116" channel-id="116",ALJAZEERA E HD
 rtp://239.186.68.171:10000
-#EXTINF:-1 tvg-id="1507" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
+#EXTINF:-1 tvg-id="" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/uk/uanddave.uk.png" tvg-chno="120" channel-id="120",U&Dave
 rtp://239.186.66.253:10000
-#EXTINF:-1 tvg-id="Quest.uk@SD" tvg-name="Quest UK" tvg-logo="https://static.epg.best/uk/quest.uk.png" tvg-chno="122" channel-id="122",Quest HD
+#EXTINF:-1 tvg-id="Quest.uk@SD" tvg-name="Quest" tvg-logo="https://static.epg.best/uk/quest.uk.png" tvg-chno="122" channel-id="122",Quest HD
 rtp://@239.186.84.2:10000
-#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 E" tvg-logo="https://static.epg.best/fr/France24e.fr.png" tvg-chno="124" channel-id="124",France24 E HD
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="https://static.epg.best/fr/France24e.fr.png" tvg-chno="124" channel-id="124",France24 E HD
 rtp://239.186.84.31:10000
-#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star UK" tvg-logo="https://static.epg.best/uk/5star.uk.png" tvg-chno="" channel-id="",5STAR
+#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star" tvg-logo="https://static.epg.best/uk/5star.uk.png" tvg-chno="" channel-id="",5STAR
 rtp://239.186.74.72:10000
-#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5Select UK" tvg-logo="https://static.epg.best/uk/5select.uk.png" tvg-chno="" channel-id="",5SELECT
+#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5SELECT" tvg-logo="https://static.epg.best/uk/5select.uk.png" tvg-chno="" channel-id="",5SELECT
 rtp://239.186.74.88:10000
-#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/uk/5action.uk.png" tvg-chno="" channel-id="",5ACTION
+#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5Action" tvg-logo="https://static.epg.best/uk/5action.uk.png" tvg-chno="" channel-id="",5ACTION
 rtp://239.186.74.84:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/uk/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="https://static.epg.best/uk/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
 rtp://239.186.74.74:10000
-#EXTINF:-1 tvg-id="1674" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/uk/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
-#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
+#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/uk/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="2017" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
+#EXTINF:-1 tvg-id="" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix HD
 rtp://239.186.84.95:10000
-#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
+#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/uk/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
-#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",Now 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",Now 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",Now 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",Now 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 90s UK" tvg-logo="https://static.epg.best/gb/NowRocks.uk.png" tvg-chno="" channel-id="",Now Rock
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s" tvg-logo="https://static.epg.best/gb/NowRocks.uk.png" tvg-chno="" channel-id="",Now Rock
 rtp://239.186.66.133:10000
 #EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/Greatmystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
 #EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/TrueCrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME
 rtp://239.186.74.107:10000
-#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatClassic.uk.png" tvg-chno="" channel-id="",GREAT! romance
+#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance" tvg-logo="https://static.epg.best/gb/GreatClassic.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
-#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
+#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Action" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
 rtp://239.186.74.58:10000
-#EXTINF:-1 tvg-id="GBNews.uk@SD" tvg-name="GB News UK" tvg-logo="https://static.epg.best/uk/GBNews.uk.png" tvg-chno="" channel-id="",GB News HD
+#EXTINF:-1 tvg-id="GBNews.uk@SD" tvg-name="GB News" tvg-logo="https://static.epg.best/uk/GBNews.uk.png" tvg-chno="" channel-id="",GB News HD
 rtp://239.186.84.57:10000
-#EXTINF:-1 tvg-id="1993" ,EU Parliament+ HD
+#EXTINF:-1 tvg-id=""  tvg-name="EU Parlament+",EU Parliament+ HD
 rtp://239.186.84.42:10000
-#EXTINF:-1 tvg-id="1992" ,EU Parliament HD
+#EXTINF:-1 tvg-id=""  tvg-name="EU Parlament",EU Parliament HD
 rtp://239.186.84.45:10000
-#EXTINF:-1 tvg-id="2056" ,CGTN DOCUMENTARY HD
+#EXTINF:-1 tvg-id=""  tvg-name="CGTN Documentary",CGTN DOCUMENTARY HD
 rtp://239.186.84.147:10000
-#EXTINF:-1tvg-id="StarTV.ch@SD" , Daystar HD (eng)
+#EXTINF:-1tvg-id="StarTV.ch@SD"  tvg-name="Star TV", Daystar HD (eng)
 rtp://239.186.70.149:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 FHD
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="282" channel-id="282",SRF1 FHD
 rtp://239.186.76.3:10000
-#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 FHD SRF zwei FHD
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="284" channel-id="284",SRF2 FHD SRF zwei FHD
 rtp://239.186.76.21:10000
-#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info FHD
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF info" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="286" channel-id="286",SRF info FHD
 rtp://239.186.76.23:10000
 #EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="175" channel-id="175",3sat HD
 rtp://239.186.68.27:10000
-#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
+#EXTINF:-1 tvg-id="3Plus.ch@SD" tvg-name="3+" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="173" channel-id="173",3+ HD
 rtp://239.186.68.14:10000
-#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
+#EXTINF:-1 tvg-id="4Plus.ch@SD" tvg-name="4+" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="177" channel-id="177",4+ HD
 rtp://239.186.68.142:10000
-#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+ CH" tvg-logo="https://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
+#EXTINF:-1 tvg-id="5Plus.ch@SD" tvg-name="5+" tvg-logo="https://static.epg.best/ch/5Plus.ch.png" tvg-chno="178" channel-id="178",5+ HD
 rtp://239.186.68.195:10000
-#EXTINF:-1 tvg-id="6Plus.ch@SD" tvg-name="6+ CH" tvg-logo="https://static.epg.best/ch/6Plus.ch.png" tvg-chno="179" channel-id="179",6+ HD
+#EXTINF:-1 tvg-id="6Plus.ch@SD" tvg-name="6+" tvg-logo="https://static.epg.best/ch/6Plus.ch.png" tvg-chno="179" channel-id="179",6+ HD
 rtp://239.186.70.116:10000
-#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="239" channel-id="239",7+ HD / Nick D CH HD
+#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ / Nickelodeon" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="239" channel-id="239",7+ HD / Nick D CH HD
 rtp://239.186.68.175:10000
-#EXTINF:-1 tvg-id="1377" tvg-name="Alf-TV CH" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
+#EXTINF:-1 tvg-id="" tvg-name="ALF-TV" tvg-logo="https://static.epg.best/de/Alf-tv.ch.png" tvg-chno="127" channel-id="127",ALF-TV CH HD
 rtp://239.186.70.179:10000
 #EXTINF:-1 tvg-id="AW1.de" tvg-name="AW1 DE" tvg-logo="https://static.epg.best/de/AW1.de.png" tvg-chno="180" channel-id="180",aw1 tv HD
 rtp://239.186.70.9:10000
 #EXTINF:-1 tvg-id="AW2.de" tvg-name="AW2 DE" tvg-logo="https://static.epg.best/de/AW2.de.png" tvg-chno="180" channel-id="182",aw2 tv HD
 rtp://239.186.84.22:10000
-#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe DE" tvg-logo="https://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
+#EXTINF:-1 tvg-id="AnixeHDSerie.de@SD" tvg-name="Anixe Serie" tvg-logo="https://static.epg.best/de/Anixe.de.png" tvg-chno="181" channel-id="181",ANIXE SERIE HD
 rtp://239.186.68.7:10000
 #EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="183" channel-id="183",ARD Das Erste HD
 rtp://239.186.68.9:10000
-#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha HD
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD-alpha" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha HD
 rtp://239.186.70.194:10000
-#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One DE" tvg-logo="https://static.epg.best/de/ARDOne.de.png" tvg-chno="186" channel-id="186",ARD ONE HD
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One" tvg-logo="https://static.epg.best/de/ARDOne.de.png" tvg-chno="186" channel-id="186",ARD ONE HD
 rtp://239.186.68.154:10000
-#EXTINF:-1 tvg-id="SRFernsehen.de@SD" tvg-name="SR fernsehen DE" tvg-logo="https://static.epg.best/de/SRfernsehen.de.png" tvg-chno="128" channel-id="128",SR fernsehen HD
+#EXTINF:-1 tvg-id="SRFernsehen.de@SD" tvg-name="SR Fernsehen" tvg-logo="https://static.epg.best/de/SRfernsehen.de.png" tvg-chno="128" channel-id="128",SR fernsehen HD
 rtp://239.186.70.190:10000
-#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="188" channel-id="188",arte D HD
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte Deutsch" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="188" channel-id="188",arte D HD
 rtp://239.186.68.11:10000
-#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="auftankentv CH" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV CH HD
+#EXTINF:-1 tvg-id="AuftankenTV.ch@SD" tvg-name="Auftanken TV" tvg-logo="" tvg-chno="189" channel-id="189",auftanken.TV CH HD
 rtp://239.186.70.117:10000
-#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="Pilatus CH" tvg-logo="https://static.epg.best/ch/pilatus.ch.png" tvg-chno="190" channel-id="190",radio Pilatus HD
+#EXTINF:-1 tvg-id="RadioPilatusTV.ch@SD" tvg-name="Radio Pilatus TV" tvg-logo="https://static.epg.best/ch/pilatus.ch.png" tvg-chno="190" channel-id="190",radio Pilatus HD
 rtp://239.186.68.104:10000
-#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="192" channel-id="192",bibel.TV HD
 rtp://239.186.68.148:10000
-#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Regio TV Bodensee DE" tvg-logo="https://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
+#EXTINF:-1 tvg-id="BodenseeTV.ch@SD" tvg-name="Bodensee TV" tvg-logo="https://static.epg.best/de/RegioTVBodensee.de.png" tvg-chno="193" channel-id="193",BTV Bodensee TV HD
 rtp://239.186.68.143:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="195" channel-id="195",BR HD
 rtp://239.186.68.26:10000
-#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="HELVETIA ONE CH" tvg-logo="https://static.epg.best/ch/helvetiaone.ch.png" tvg-chno="199" channel-id="199",HELVETIA ONE HD
+#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="Helvetia One TV" tvg-logo="https://static.epg.best/ch/helvetiaone.ch.png" tvg-chno="199" channel-id="199",HELVETIA ONE HD
 rtp://239.186.70.103:10000
-#EXTINF:-1 tvg-id="116" tvg-name="Davos Klosters CH" tvg-logo="https://static.epg.best/ch/DavosKlosters.ch.png" tvg-chno="200" channel-id="200",Davos Klosters HD
+#EXTINF:-1 tvg-id="" tvg-name="Davos Klosters CH" tvg-logo="https://static.epg.best/ch/DavosKlosters.ch.png" tvg-chno="200" channel-id="200",Davos Klosters HD
 rtp://239.186.68.216:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel D" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",eoTV RiC
+#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RIC TV" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",eoTV RiC
 rtp://239.186.64.129:10000
-#EXTINF:-1 tvg-id="95" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="129" channel-id="129",HGTV (deu)
+#EXTINF:-1 tvg-id="" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="129" channel-id="129",HGTV (deu)
 rtp://239.186.74.40:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="209" channel-id="209",Euronews. D HD
 rtp://239.186.70.101:10000
-#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel DE" tvg-logo="https://static.epg.best/de/HopeChannel.de.png" tvg-chno="215" channel-id="215",HopeTV HD
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope TV" tvg-logo="https://static.epg.best/de/HopeChannel.de.png" tvg-chno="215" channel-id="215",HopeTV HD
 rtp://239.186.68.251:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="217" channel-id="217",hr HD
 rtp://239.186.68.156:10000
-#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE24 DE" tvg-logo="https://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE HD
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE" tvg-logo="https://static.epg.best/de/HSE24.de.png" tvg-chno="218" channel-id="218",HSE HD
 rtp://239.186.84.162:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins CH HD
 rtp://239.186.68.15:10000
-#EXTINF:-1 tvg-id="kabeleinsDoku.de@SD" tvg-name="Kabel 1 Doku DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins Doku CH HD
+#EXTINF:-1 tvg-id="kabeleinsDoku.de@SD" tvg-name="kabel eins Doku" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins Doku CH HD
 rtp://239.186.70.86:10000
-#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="224" channel-id="224",Kanal9 HD
 rtp://239.186.68.145:10000
-#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKa" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="226" channel-id="226",KiKA HD
 rtp://239.186.68.28:10000
-#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv HD
+#EXTINF:-1 tvg-id="KTV.at@SD" tvg-name="K-TV" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv HD
 rtp://239.186.84.137:10000
-#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY CH HD
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY CH HD
 rtp://239.186.70.211:10000
-#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
+#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="230" channel-id="230",mdr HD
 rtp://239.186.68.162:10000
-#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="Melodie.tv AT" tvg-logo="https://static.epg.best/at/melodietv.at.png" tvg-chno="231" channel-id="231",Melodie.tv
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="https://static.epg.best/at/melodietv.at.png" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="Musig24TV.ch@SD" tvg-name="Musig24 CH" tvg-logo="https://static.epg.best/ch/Musig24.ch.png" tvg-chno="234" channel-id="234",musig24 HD
+#EXTINF:-1 tvg-id="Musig24TV.ch@SD" tvg-name="musig24" tvg-logo="https://static.epg.best/ch/Musig24.ch.png" tvg-chno="234" channel-id="234",musig24 HD
 rtp://239.186.68.207:10000
-#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
+#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="237" channel-id="237",NDR HD
 rtp://239.186.68.29:10000
-#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="Nitro" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
 #EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="245" channel-id="245",ORF1 HD
 rtp://239.186.68.12:10000
@@ -321,139 +321,139 @@ rtp://239.186.68.12:10000
 rtp://239.186.68.13:10000
 #EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3 HD
 rtp://239.186.70.122:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="250" channel-id="250",phoenix HD
 rtp://239.186.68.30:10000
-#EXTINF:-1 tvg-id="ProSiebenSchweiz.ch@SD" tvg-name="ProSieben DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben CH HD
+#EXTINF:-1 tvg-id="ProSiebenSchweiz.ch@SD" tvg-name="ProSieben" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben CH HD
 rtp://239.186.68.17:10000
-#EXTINF:-1 tvg-id="ProSiebenMaxx.de@SD" tvg-name="ProSieben Maxx DE" tvg-logo="https://static.epg.best/de/ProSiebenMaxx.de.png" tvg-chno="252" channel-id="252",ProSieben MAXX CH HD
+#EXTINF:-1 tvg-id="ProSiebenMaxx.de@SD" tvg-name="ProSieben MAXX" tvg-logo="https://static.epg.best/de/ProSiebenMaxx.de.png" tvg-chno="252" channel-id="252",ProSieben MAXX CH HD
 rtp://239.186.70.87:10000
 #EXTINF:-1 tvg-id="PULSacht.ch" tvg-name="Puls acht CH" tvg-logo="https://static.epg.best/ch/PULSacht.ch.png" tvg-chno="254" channel-id="254",Puls acht HD
 rtp://239.186.68.191:10000
 #EXTINF:-1 tvg-id="r-9.at" tvg-name="R-9 AT" tvg-logo="https://static.epg.best/at/r-9.at.png" tvg-chno="255" channel-id="255",R9 Oesterreich HD
 rtp://239.186.68.248:10000
-#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
+#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="257" channel-id="257",rbb HD
 rtp://239.186.68.157:10000
-#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="Regio TVplus CH" tvg-logo="https://static.epg.best/de/RegioTVplus.ch.png" tvg-chno="258" channel-id="258",regioTVplus HD
+#EXTINF:-1 tvg-id="RegioTVplus.ch@SD" tvg-name="regioTVplus" tvg-logo="https://static.epg.best/de/RegioTVplus.ch.png" tvg-chno="258" channel-id="258",regioTVplus HD
 rtp://239.186.70.40:10000
-#EXTINF:-1 tvg-id="RheinweltenTV.ch@SD" tvg-name="Rheinwelten CH" tvg-logo="https://static.epg.best/de/Rheinwelten.ch.png" tvg-chno="132" channel-id="132",Rheinwelten HD
+#EXTINF:-1 tvg-id="RheinweltenTV.ch@SD" tvg-name="Rheinwelten TV" tvg-logo="https://static.epg.best/de/Rheinwelten.ch.png" tvg-chno="132" channel-id="132",Rheinwelten HD
 rtp://239.186.70.202:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH
+#EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="260" channel-id="260",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
+#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTLZWEI CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL Plus DE" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
+#EXTINF:-1 tvg-id="" tvg-name="RTL Plus DE" tvg-logo="https://static.epg.best/de/RTLup.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1 CH" tvg-logo="https://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
+#EXTINF:-1 tvg-id="S1.ch@SD" tvg-name="S1" tvg-logo="https://static.epg.best/ch/S1.ch.png" tvg-chno="263" channel-id="263",S1 HD
 rtp://239.186.68.147:10000
-#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH HD
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="SAT.1" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH HD
 rtp://239.186.68.16:10000
-#EXTINF:-1 tvg-id="SAT1Gold.de@SD" tvg-name="Sat 1 Gold DE" tvg-logo="https://static.epg.best/de/Sat1Gold.de.png" tvg-chno="265" channel-id="265",SAT.1 GOLD CH HD
+#EXTINF:-1 tvg-id="SAT1Gold.de@SD" tvg-name="SAT.1 GOLD" tvg-logo="https://static.epg.best/de/Sat1Gold.de.png" tvg-chno="265" channel-id="265",SAT.1 GOLD CH HD
 rtp://239.186.70.88:10000
-#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="ServusTV DE" tvg-logo="https://static.epg.best/de/ServusTV.de.png" tvg-chno="270" channel-id="270",ServusTV Deutschland
+#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="https://static.epg.best/de/ServusTV.de.png" tvg-chno="270" channel-id="270",ServusTV Deutschland
 rtp://239.186.64.136:10000
-#EXTINF:-1 tvg-id="1325" tvg-name="Session Nationalrat CH" tvg-logo="https://static.epg.best/ch/SessionNationalrat.ch.png" tvg-chno="272" channel-id="272",SessionNationalrat HD
+#EXTINF:-1 tvg-id="" tvg-name="Session Nationalrat CH" tvg-logo="https://static.epg.best/ch/SessionNationalrat.ch.png" tvg-chno="272" channel-id="272",SessionNationalrat HD
 rtp://239.186.70.127:10000
 #EXTINF:-1 tvg-id="SessionStaendenrat.ch" tvg-name="SessionStaendenrat CH" tvg-logo="https://static.epg.best/ch/SessionStaendenrat.ch.png" tvg-chno="274" channel-id="274",SessionStaendenrat HD
 rtp://239.186.70.128:10000
-#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf CH" tvg-logo="https://static.epg.best/ch/SHf.ch.png" tvg-chno="277" channel-id="277",SHf HD
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf - Schaffhauser Fernsehen" tvg-logo="https://static.epg.best/ch/SHf.ch.png" tvg-chno="277" channel-id="277",SHf HD
 rtp://239.186.68.139:10000
-#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH HD
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="sixx" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH HD
 rtp://239.186.68.34:10000
-#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",Sport1 CH HD
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport1" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="280" channel-id="280",Sport1 CH HD
 rtp://239.186.68.159:10000
-#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",STAR TV CH HD
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="288" channel-id="288",STAR TV CH HD
 rtp://239.186.68.188:10000
-#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="GameTV CH" tvg-logo="https://static.epg.best/ch/Gametv.ch.png" tvg-chno="289" channel-id="289",GAMETV CH HD
+#EXTINF:-1 tvg-id="GameTV.ch@SD" tvg-name="Game TV" tvg-logo="https://static.epg.best/ch/Gametv.ch.png" tvg-chno="289" channel-id="289",GAMETV CH HD
 rtp://239.186.70.10:10000
-#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL DE" tvg-logo="https://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",RTL SUPER
+#EXTINF:-1 tvg-id="RTLSuper.de@SD" tvg-name="Super RTL" tvg-logo="https://static.epg.best/de/SuperRTL.de.png" tvg-chno="290" channel-id="290",RTL SUPER
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="Swiss1 CH" tvg-logo="https://static.epg.best/ch/Swiss1.ch.png" tvg-chno="292" channel-id="292",Swiss1 HD
+#EXTINF:-1 tvg-id="Swiss1.ch@SD" tvg-name="SWISS1" tvg-logo="https://static.epg.best/ch/Swiss1.ch.png" tvg-chno="292" channel-id="292",Swiss1 HD
 rtp://239.186.68.97:10000
-#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="294" channel-id="294",SWR >> HD
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="294" channel-id="294",SWR >> HD
 rtp://239.186.68.25:10000
-#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="296" channel-id="296",Tagesschau24 HD
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau24" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="296" channel-id="296",Tagesschau24 HD
 rtp://239.186.68.161:10000
-#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="298" channel-id="298",Tele1 HD
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele 1" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="298" channel-id="298",Tele1 HD
 rtp://239.186.68.176:10000
-#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",telebaern.tv HD
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Bärn" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="301" channel-id="301",telebaern.tv HD
 rtp://239.186.68.38:10000
-#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="TELE D CH" tvg-logo="https://static.epg.best/ch/teled.ch.png" tvg-chno="304" channel-id="304",TELE D HD
+#EXTINF:-1 tvg-id="TeleD.ch@SD" tvg-name="Tele D" tvg-logo="https://static.epg.best/ch/teled.ch.png" tvg-chno="304" channel-id="304",TELE D HD
 rtp://239.186.68.217:10000
-#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="306" channel-id="306",Tele M1 HD
 rtp://239.186.68.102:10000
-#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="308" channel-id="308",Tele Top HD
 rtp://239.186.68.252:10000
-#EXTINF:-1 tvg-id="Televista.ch@SD" tvg-name="televista CH" tvg-logo="https://static.epg.best/ch/televista.ch.png" tvg-chno="163" channel-id="163",TELEVISTA HD
+#EXTINF:-1 tvg-id="Televista.ch@SD" tvg-name="Televista" tvg-logo="https://static.epg.best/ch/televista.ch.png" tvg-chno="163" channel-id="163",TELEVISTA HD
 rtp://239.186.70.182:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="TELE Z CH" tvg-logo="https://static.epg.best/ch/telez.ch.png" tvg-chno="310" channel-id="310",TELEZ HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="https://static.epg.best/ch/telez.ch.png" tvg-chno="310" channel-id="310",TELEZ HD
 rtp://239.186.68.205:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zentral CH" tvg-logo="https://static.epg.best/ch/TeleZentral.ch.png" tvg-chno="311" channel-id="311",Tele Zentral Schweiz HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="https://static.epg.best/ch/TeleZentral.ch.png" tvg-chno="311" channel-id="311",Tele Zentral Schweiz HD
 rtp://239.186.68.166:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="313" channel-id="313",TELE ZURI HD
 rtp://239.186.68.189:10000
-#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Telebasel" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="315" channel-id="315",Telebasel HD
 rtp://239.186.68.206:10000
-#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="317" channel-id="317",blue ZOOM D HD
+#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="blue Zoom D" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="317" channel-id="317",blue ZOOM D HD
 rtp://239.186.68.155:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo Plus" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
-#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="Tele Suedostschweiz CH" tvg-logo="https://static.epg.best/ch/TeleSuedostschweiz.ch.png" tvg-chno="322" channel-id="322",TSO TeleSuedostschweiz HD
+#EXTINF:-1 tvg-id="Sudostschweiz.ch@SD" tvg-name="TV Südostschweiz" tvg-logo="https://static.epg.best/ch/TeleSuedostschweiz.ch.png" tvg-chno="322" channel-id="322",TSO TeleSuedostschweiz HD
 rtp://239.186.68.218:10000
-#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="TV Oberwallis CH" tvg-logo="https://static.epg.best/ch/TVOberwallis.ch.png" tvg-chno="324" channel-id="324",TV Oberwallis HD
+#EXTINF:-1 tvg-id="TVOberwallis.ch@SD" tvg-name="TV Oberwallis" tvg-logo="https://static.epg.best/ch/TVOberwallis.ch.png" tvg-chno="324" channel-id="324",TV Oberwallis HD
 rtp://239.186.70.5:10000
-#EXTINF:-1 tvg-id="1910" tvg-name="TV24 CH" tvg-logo="https://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
+#EXTINF:-1 tvg-id="TV24.ch@SD" tvg-name="TV24" tvg-logo="https://static.epg.best/ch/TV24.ch.png" tvg-chno="326" channel-id="326",TV24 HD
 rtp://239.186.68.190:10000
 #EXTINF:-1 tvg-id="TV25.ch" tvg-name="TV 25 CH" tvg-logo="https://static.epg.best/ch/TV25.ch.png" tvg-chno="327" channel-id="327",TV25 HD
 rtp://239.186.70.20:10000
-#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="329" channel-id="329",tvo HD
 rtp://239.186.70.4:10000
-#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
+#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="335" channel-id="335",WDR HD
 rtp://239.186.68.24:10000
-#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder DE" tvg-logo="https://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV CH HD
+#EXTINF:-1 tvg-id="WeltderWunderTV.de@SD" tvg-name="Welt der Wunder TV" tvg-logo="https://static.epg.best/de/WeltDerWunder.de.png" tvg-chno="337" channel-id="337",Welt der Wunder TV CH HD
 rtp://239.186.68.198:10000
-#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="WetterTV CH" tvg-logo="https://static.epg.best/ch/Wettertv.ch.png" tvg-chno="338" channel-id="338",wetter.tv CH HD
+#EXTINF:-1 tvg-id="WettercomTV.de@SD" tvg-name="Wetter.TV" tvg-logo="https://static.epg.best/ch/Wettertv.ch.png" tvg-chno="338" channel-id="338",wetter.tv CH HD
 rtp://239.186.70.119:10000
-#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="340" channel-id="340",ZDF CH HD
 rtp://239.186.68.10:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDFinfo" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="342" channel-id="342",zdf info HD
 rtp://239.186.68.32:10000
-#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDFneo" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="344" channel-id="344",zdf_neo HD
 rtp://239.186.68.31:10000
-#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="135" channel-id="135",VOXup
+#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="135" channel-id="135",VOXup
 rtp://239.186.74.70:10000
-#EXTINF:-1 tvg-id="SwissSportTV.ch@SD" tvg-name="SwissSportTV CH" tvg-logo="https://static.epg.best/ch/swisssporttv.ch.png" tvg-chno="139" channel-id="139",swiss sport tv HD
+#EXTINF:-1 tvg-id="SwissSportTV.ch@SD" tvg-name="Swiss Sport TV" tvg-logo="https://static.epg.best/ch/swisssporttv.ch.png" tvg-chno="139" channel-id="139",swiss sport tv HD
 rtp://@239.186.84.17:10000
-#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="Schlager Deluxe DE" tvg-logo="https://static.epg.best/de/SchlagerDeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
+#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="Schlager Deluxe" tvg-logo="https://static.epg.best/de/SchlagerDeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
 rtp://239.186.74.105:10000
-#EXTINF:-1 tvg-id="1903" tvg-name="Schlager Paradies DE" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
+#EXTINF:-1 tvg-id="" tvg-name="Schlager Paradies DE" tvg-logo="https://static.epg.best/de/SchlagerParadies.de.png" tvg-chno="" channel-id="",SCHLAGER PARADIES.TV HD
 rtp://239.186.84.37:10000
-#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="Volksmusik TV DE" tvg-logo="https://static.epg.best/de/Volksmusik.de.png" tvg-chno="" channel-id="",Volksmusik.tv HD
+#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="Volksmusik.TV" tvg-logo="https://static.epg.best/de/Volksmusik.de.png" tvg-chno="" channel-id="",Volksmusik.tv HD
 rtp://239.186.70.97:10000
-#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" ,More Than Sports TV HD
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD"  tvg-name="More Than Sports TV",More Than Sports TV HD
 rtp://239.186.70.28:10000
-#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD" ,Folx HD
+#EXTINF:-1 tvg-id="FolxMusicTelevision.de@SD"  tvg-name="folx.tv",Folx HD
 rtp://239.186.68.121:10000
-#EXTINF:-1 tvg-id="OneMusicTelevision.de@SD" tvg-name="One Music DE" tvg-logo="https://static.epg.best/de/onemusic.de.png" tvg-chno="" channel-id="",ONE 1 Music TV HD
+#EXTINF:-1 tvg-id="OneMusicTelevision.de@SD" tvg-name="One Music Television" tvg-logo="https://static.epg.best/de/onemusic.de.png" tvg-chno="" channel-id="",ONE 1 Music TV HD
 rtp://239.186.70.214:10000
-#EXTINF:-1 tvg-id="ZweiMusicTelevision.de@SD" tvg-name="Zwei Music DE" tvg-logo="https://static.epg.best/de/zweimusic.de.png" tvg-chno="" channel-id="",ZWEI 2 Music TV HD
+#EXTINF:-1 tvg-id="ZweiMusicTelevision.de@SD" tvg-name="Zwei Music Television" tvg-logo="https://static.epg.best/de/zweimusic.de.png" tvg-chno="" channel-id="",ZWEI 2 Music TV HD
 rtp://239.186.70.204:10000
-#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo TV DE" tvg-logo="https://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="" channel-id="",MARCO POLO TV HD
+#EXTINF:-1 tvg-id="MarcoPoloTV.de@SD" tvg-name="Marco Polo" tvg-logo="https://static.epg.best/de/MarcoPoloTV.de.png" tvg-chno="" channel-id="",MARCO POLO TV HD
 rtp://239.186.84.60:10000
 #EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORFSport.at.png" tvg-chno="249" channel-id="249",ORF SPORT+ HD
 rtp://239.186.84.80:10000
-#EXTINF:-1 tvg-id="ArcadiaTV.li@SD" tvg-name="Arcadia TV RO" tvg-logo="https://static.epg.best/ro/ArcadiaTV.ro.png" tvg-chno="" channel-id="" ,ARCADIA WORLD TV HD
+#EXTINF:-1 tvg-id="ArcadiaTV.li@SD" tvg-name="ARCADIA world TV" tvg-logo="https://static.epg.best/ro/ArcadiaTV.ro.png" tvg-chno="" channel-id="" ,ARCADIA WORLD TV HD
 rtp://239.186.84.1:10000
 #EXTINF:-1 ,DMF HD
 rtp://239.186.70.96:10000
-#EXTINF:-1 tvg-id="2055" ,stimmungsgarten.tv
+#EXTINF:-1 tvg-id=""  tvg-name="Stimmungsgarten TV",stimmungsgarten.tv
 rtp://239.186.74.148:10000
-#EXTINF:-1 tvg-id="2041" ,justcooking.tv (deu)
+#EXTINF:-1 tvg-id="" ,justcooking.tv (deu)
 rtp://239.186.74.150:10000
-#EXTINF:-1 tvg-id="TVRheintal.ch@SD" ,TV RT HD (deu) TV   TV Rheintal HD
+#EXTINF:-1 tvg-id="TVRheintal.ch@SD"  tvg-name="TV Rheintal",TV RT HD (deu) TV   TV Rheintal HD
 rtp://239.186.84.171:10000
 #EXTINF:-1 ,I-TV HD
 rtp://239.186.70.91:10000
@@ -463,170 +463,170 @@ rtp://239.186.74.157:10000
 rtp://239.186.70.126:10000
 #EXTINF:-1 ,DF1 HD (deu)
 rtp://239.186.68.93:10000
-#EXTINF:-1tvg-id="TeleD.ch@SD" ,TELEGOLD HD (deu)
+#EXTINF:-1tvg-id="TeleD.ch@SD"  tvg-name="Tele D",TELEGOLD HD (deu)
 rtp://239.186.68.53:10000
 #EXTINF:-1,Hohenrausch HD
 rtp://239.186.70.140:10000
-#EXTINF:-1tvg-id="LiloTV.de@SD" ,lilo TV
+#EXTINF:-1tvg-id="LiloTV.de@SD"  tvg-name="Lilo TV",lilo TV
 rtp://239.186.74.82:10000
-#EXTINF:-1tvg-id="1065" ,network tv HD
+#EXTINF:-1tvg-id="" ,network tv HD
 rtp://239.186.84.173:10000
-#EXTINF:-1 tvg-id="296" tvg-name="ntv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="340" channel-id="",ntv
+#EXTINF:-1 tvg-id="" tvg-name="ntv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="340" channel-id="",ntv
 rtp://239.186.64.29:10000
-#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="canalbde CH" tvg-logo="https://static.epg.best/ch/canalbde.ch.png" tvg-chno="" channel-id="",Canalb de HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="https://static.epg.best/ch/canalbde.ch.png" tvg-chno="" channel-id="",Canalb de HD
 rtp://239.186.70.173:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="403" channel-id="403",RSI LA1 FHD
 rtp://239.186.76.24:10000
-#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 FHD
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="405" channel-id="405",RSI LA2 FHD
 rtp://239.186.76.25:10000
-#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="411" channel-id="411",teleticino HD
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="Tele Ticino" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="411" channel-id="411",teleticino HD
 rtp://239.186.68.201:10000
 #EXTINF:-1 tvg-id="7GTelecity.it" tvg-name="7G Telecity IT" tvg-logo="https://static.epg.best/it/7GTelecity.it.png" tvg-chno="346" channel-id="346",telecity HD
 rtp://239.186.84.109:10000
-#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="Almatv IT" tvg-logo="https://static.epg.best/it/almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
+#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="ALMA TV" tvg-logo="https://static.epg.best/it/almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="antenna3 IT" tvg-logo="https://static.epg.best/it/antenna3.it.png" tvg-chno="348" channel-id="348",ANTENNA3 HD
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="Antenna 3" tvg-logo="https://static.epg.best/it/antenna3.it.png" tvg-chno="348" channel-id="348",ANTENNA3 HD
 rtp://239.186.70.79:10000
-#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="Canale Italia IT" tvg-logo="https://static.epg.best/it/canaleitalia.it.png" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="Canale Italia" tvg-logo="https://static.epg.best/it/canaleitalia.it.png" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo HD
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo HD
 rtp://239.186.70.172:10000
-#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="ClassTV Moda IT" tvg-logo="https://static.epg.best/it/ClassTVModa.it.png" tvg-chno="354" channel-id="354",Class TV Moda HD
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="Class TV Moda" tvg-logo="https://static.epg.best/it/ClassTVModa.it.png" tvg-chno="354" channel-id="354",Class TV Moda HD
 rtp://239.186.84.180:10000
-#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="Discovery IT" tvg-logo="https://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I HD
+#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="Discovery F" tvg-logo="https://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I HD
 rtp://239.186.68.149:10000
-#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros. Discovery Real Time HD
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros. Discovery Real Time HD
 rtp://239.186.84.103:10000
-#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="361" channel-id="361",Warner Bros. Discovery NOVE HD
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="361" channel-id="361",Warner Bros. Discovery NOVE HD
 rtp://239.186.70.233:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros. Discovery DMAX I HD
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros. Discovery DMAX I HD
 rtp://239.186.84.89:10000
-#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros. Discovery Giallo HD
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros. Discovery Giallo HD
 rtp://239.186.84.99:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend US" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="https://static.epg.best/us/MotorTrend.us.png" tvg-chno="359" channel-id="359",Warner Bros. Discovery MOTORTREND HD
 rtp://239.186.84.102:10000
 #EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros. Discovery food network I HD
 rtp://239.186.84.91:10000
-#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros. Discovery K2
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros. Discovery K2
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros. Discovery Frisbee
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros. Discovery Frisbee
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="95" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
+#EXTINF:-1 tvg-id="" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros. Discovery HGTV HD
 rtp://239.186.84.101:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
-#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="Italia Channel IT" tvg-logo="https://static.epg.best/it/ItaliaChannel.it.png" tvg-chno="365" channel-id="365",Italia Channel 123
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="Italia Channel" tvg-logo="https://static.epg.best/it/ItaliaChannel.it.png" tvg-chno="365" channel-id="365",Italia Channel 123
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="367" channel-id="367",LA7 HD
 rtp://239.186.70.7:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7cinama IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA HD
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA HD
 rtp://239.186.70.6:10000
-#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="372" channel-id="372",MEDIASET Canale5 HD
 rtp://239.186.68.163:10000
-#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
 rtp://239.186.68.165:10000
-#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4 HD
+#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="Rete 4" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4 HD
 rtp://239.186.70.188:10000
-#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET HD
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset" tvg-logo="https://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET HD
 rtp://239.186.68.46:10000
-#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5 HD
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5 HD
 rtp://239.186.84.88:10000
-#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2 HD
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2 HD
 rtp://239.186.84.123:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA HD
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA HD
 rtp://239.186.68.128:10000
-#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus HD
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus HD
 rtp://239.186.70.72:10000
-#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime HD
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime HD
 rtp://239.186.84.125:10000
-#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS HD
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="IRIS" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS HD
 rtp://239.186.84.98:10000
-#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing HD
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing I" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing HD
 rtp://239.186.84.142:10000
-#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",CARTOONITO HD
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito F" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",CARTOONITO HD
 rtp://239.186.84.139:10000
-#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCom24 HD
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="TGCom24" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCom24 HD
 rtp://239.186.84.86:10000
-#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34 HD
+#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34 HD
 rtp://239.186.68.245:10000
-#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 HD
+#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="Twentyseven" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 HD
 rtp://239.186.84.87:10000
-#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai 1" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="385" channel-id="385",Rai1 HD
 rtp://239.186.68.36:10000
-#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai 2" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="387" channel-id="387",Rai2 HD
 rtp://239.186.70.77:10000
-#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai 3" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="389" channel-id="389",Rai3 HD
 rtp://239.186.70.78:10000
-#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4 HD
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4 HD
 rtp://239.186.70.43:10000
-#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie HD
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie HD
 rtp://239.186.84.140:10000
-#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium FullHD
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium FullHD
 rtp://239.186.76.2:10000
-#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp HD
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp HD
 rtp://239.186.84.18:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia HD
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia HD
 rtp://239.186.70.110:10000
-#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola HD
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola HD
 rtp://239.186.70.111:10000
-#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24 HD
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24 HD
 rtp://239.186.70.84:10000
-#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport HD
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="Rai Sport +" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="398" channel-id="398",Rai Sport HD
 rtp://239.186.70.2:10000
-#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="140" channel-id="140",radionorba TV HD
+#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="Radionorba TV" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="140" channel-id="140",radionorba TV HD
 rtp://239.186.84.20:10000
-#EXTINF:-1 tvg-id="RTL1025TV.it@SD" tvg-name="RTL102.5TV IT" tvg-logo="https://static.epg.best/it/RTL1025TV.it.png" tvg-chno="141" channel-id="141",RTL 102.5 TV HD
+#EXTINF:-1 tvg-id="RTL1025TV.it@SD" tvg-name="RTL 102.5 TV" tvg-logo="https://static.epg.best/it/RTL1025TV.it.png" tvg-chno="141" channel-id="141",RTL 102.5 TV HD
 rtp://239.186.70.181:10000
-#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24 HD
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="sky TG 24" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24 HD
 rtp://239.186.70.109:10000
-#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport italia plus HD
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="SPORTITALIA" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sport italia plus HD
 rtp://239.186.70.14:10000
-#EXTINF:-1 tvg-id="2049" tvg-name="SoloCalcio IT" tvg-logo="https://static.epg.best/it/SoloCalcio.it.png" tvg-chno="407" channel-id="407",Si SOLOCALCIO HD
+#EXTINF:-1 tvg-id="" tvg-name="SoloCalcio IT" tvg-logo="https://static.epg.best/it/SoloCalcio.it.png" tvg-chno="407" channel-id="407",Si SOLOCALCIO HD
 rtp://239.186.84.94:10000
-#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="super! IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super!" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis IT" tvg-logo="https://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SuperTennis HD
+#EXTINF:-1 tvg-id="SuperTennis.it@SD" tvg-name="SuperTennis TV" tvg-logo="https://static.epg.best/it/SuperTennis.it.png" tvg-chno="409" channel-id="409",SuperTennis HD
 rtp://239.186.70.154:10000
-#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="telelombardia IT" tvg-logo="https://static.epg.best/it/telelombardia.it.png" tvg-chno="412" channel-id="412",TELELOMBARDIA HD
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="Telelombardia" tvg-logo="https://static.epg.best/it/telelombardia.it.png" tvg-chno="412" channel-id="412",TELELOMBARDIA HD
 rtp://239.186.84.104:10000
-#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="telenova IT" tvg-logo="https://static.epg.best/it/telenova.it.png" tvg-chno="413" channel-id="413",TELENOVA HD
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="Telenova" tvg-logo="https://static.epg.best/it/telenova.it.png" tvg-chno="413" channel-id="413",TELENOVA HD
 rtp://239.186.84.113:10000
-#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",TV8 Italia HD
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",TV8 Italia HD
 rtp://239.186.84.28:10000
-#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="Uninettuno IT" tvg-logo="https://static.epg.best/it/uninettuno.it" tvg-chno="417" channel-id="417",UNINETTUNO.tv
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="UniNettuno University TV" tvg-logo="https://static.epg.best/it/uninettuno.it" tvg-chno="417" channel-id="417",UNINETTUNO.tv
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000 HD
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000 HD
 rtp://239.186.84.73:10000
-#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/Espansione.it.png" tvg-chno="414" channel-id="414",Espansione TV HD
+#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione TV" tvg-logo="https://static.epg.best/it/Espansione.it.png" tvg-chno="414" channel-id="414",Espansione TV HD
 rtp://239.186.84.90:10000
-#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Topcalcio24 IT" tvg-logo="https://static.epg.best/it/Topcalcio24.it.png" tvg-chno="420" channel-id="420",TOP CALCIO 24 HD
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Top Calcio 24" tvg-logo="https://static.epg.best/it/Topcalcio24.it.png" tvg-chno="420" channel-id="420",TOP CALCIO 24 HD
 rtp://239.186.84.105:10000
-#EXTINF:-1 tvg-id="SenatoTV.it@SD" ,Senato TV HD
+#EXTINF:-1 tvg-id="SenatoTV.it@SD"  tvg-name="Senato TV",Senato TV HD
 rtp://239.186.70.114:10000
-#EXTINF:-1 tvg-id="DeejayTV.it@SD" tvg-name="DeejayTV IT" tvg-logo="https://static.epg.best/it/Deejay.it.png" tvg-chno="" channel-id="",Deejay TV HD
+#EXTINF:-1 tvg-id="DeejayTV.it@SD" tvg-name="Deejay TV" tvg-logo="https://static.epg.best/it/Deejay.it.png" tvg-chno="" channel-id="",Deejay TV HD
 rtp://239.186.70.152:10000
-#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="SMtv San Marino IT" tvg-logo="https://static.epg.best/it/SMtvSanMarino.it.png" tvg-chno="" channel-id="",Rtv San Marino HD
+#EXTINF:-1 tvg-id="MTV.de@SD" tvg-name="MTV" tvg-logo="https://static.epg.best/it/SMtvSanMarino.it.png" tvg-chno="" channel-id="",Rtv San Marino HD
 rtp://239.186.84.23:10000
-#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD" ,camera dei deputati
+#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD"  tvg-name="Camera dei Deputati",camera dei deputati
 rtp://239.186.74.59:10000
-#EXTINF:-1 tvg-id="RadioTicinoChannel.it@SD" ,Radio Ticino channel HD
+#EXTINF:-1 tvg-id="RadioTicinoChannel.it@SD"  tvg-name="Radio Ticino Channel",Radio Ticino channel HD
 rtp://239.186.68.192:10000
-#EXTINF:-1 tvg-id="ParolediVita.it@SD" ,Parole Di Vita HD
+#EXTINF:-1 tvg-id="ParolediVita.it@SD"  tvg-name="Parole di Vita",Parole Di Vita HD
 rtp://239.186.68.179:10000
-#EXTINF:-1 tvg-id="2060" ,TRENTINO TV HD
+#EXTINF:-1 tvg-id=""  tvg-name="Trentino TV",TRENTINO TV HD
 rtp://239.186.84.141:10000
-#EXTINF:-1 tvg-id="2057" ,telenuovo HD
+#EXTINF:-1 tvg-id=""  tvg-name="Telenuovo",telenuovo HD
 rtp://239.186.84.143:10000
-#EXTINF:-1 tvg-id="2061" ,CAPRI SPORT HD
+#EXTINF:-1 tvg-id="" ,CAPRI SPORT HD
 rtp://239.186.84.150:10000
-#EXTINF:-1 tvg-id="2064" ,RADIO ITALIA HD
+#EXTINF:-1 tvg-id="" ,RADIO ITALIA HD
 rtp://239.186.84.152:10000
-#EXTINF:-1 tvg-id="2063" ,TELECUPOLE HD
+#EXTINF:-1 tvg-id=""  tvg-name="Telecupole",TELECUPOLE HD
 rtp://239.186.84.156:10000
 #EXTINF:-1 ,R55 Rete55 TV HD (ita)
 rtp://239.186.84.178:10000
@@ -635,132 +635,132 @@ rtp://239.186.70.33:10000
 #EXTINF:-1,wedotv Movies IT HD (ita)
 rtp://239.186.70.169:10000
 #EXTREM:portuguese
-#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="471" channel-id="471",Record HD
 rtp://239.186.68.246:10000
-#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP mundo_.
+#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP mundo_.
 rtp://239.186.64.77:10000
 #EXTREM:spanish
-#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragon int ES" tvg-logo="https://static.epg.best/es/aragonint.es.png" tvg-chno="143" channel-id="143",Aragon int
+#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragón TV Int" tvg-logo="https://static.epg.best/es/aragonint.es.png" tvg-chno="143" channel-id="143",Aragon int
 rtp://239.186.66.62:10000
-#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas HD
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="TV Ora" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas HD
 rtp://239.186.68.45:10000
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="Canal Sur Andalucía ES" tvg-logo="https://static.epg.best/es/CanalAndalucia.es.png" tvg-chno="467" channel-id="467",Andalucia TV
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="Canal Sur Andalucía" tvg-logo="https://static.epg.best/es/CanalAndalucia.es.png" tvg-chno="467" channel-id="467",Andalucia TV
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",TV Galicia HD
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="Televisión de Galicia" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",TV Galicia HD
 rtp://239.186.84.33:10000
-#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="TVE Internacional Europa/África ES" tvg-logo="https://static.epg.best/es/TVEIntEu.es.png" tvg-chno="469" channel-id="469",tve int HD
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="TVE Internacional" tvg-logo="https://static.epg.best/es/TVEIntEu.es.png" tvg-chno="469" channel-id="469",tve int HD
 rtp://239.186.68.178:10000
-#EXTINF:-1 tvg-id="Telesur.ve@SD" tvg-name="Telesur ES" tvg-logo="https://static.epg.best/es/Telesur.es.png" tvg-chno="" channel-id="",teleSUR HD (spa)
+#EXTINF:-1 tvg-id="Telesur.ve@SD" tvg-name="teleSUR" tvg-logo="https://static.epg.best/es/Telesur.es.png" tvg-chno="" channel-id="",teleSUR HD (spa)
 rtp://239.186.84.19:10000
 #EXTINF:-1 ,cvi HD Cuba Visio Internacional
 rtp://239.186.84.146:10000
 #EXTREM:turkish
-#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",Euro D HD
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",Euro D HD
 rtp://239.186.84.138:10000
-#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Euro Star" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk HD
+#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk HD
 rtp://239.186.70.184:10000
-#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="ATV TR" tvg-logo="https://static.epg.best/tr/ATV.tr.png" tvg-chno="421" channel-id="421",atv avrupa HD
+#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="ATV (TR)" tvg-logo="https://static.epg.best/tr/ATV.tr.png" tvg-chno="421" channel-id="421",atv avrupa HD
 rtp://239.186.84.24:10000
-#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX HD
 rtp://239.186.68.226:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK HD
 rtp://239.186.84.36:10000
-#EXTINF:-1 tvg-id="602" tvg-name="TGRTEU TR" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="" tvg-name="TGRT EU" tvg-logo="https://static.epg.best/tr/TGRTEU.tr.png" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT Turk HD
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT Turk HD
 rtp://239.186.70.210:10000
-#EXTINF:-1 tvg-id="TRTBelgesel.tr@SD" tvg-name="TRT BELGESEL TR" tvg-logo="https://static.epg.best/tr/TRTBELGESEL.tr.png" tvg-chno="146" channel-id="146",TRT Belgesel HD
+#EXTINF:-1 tvg-id="TRTBelgesel.tr@SD" tvg-name="TRT Belgesel" tvg-logo="https://static.epg.best/tr/TRTBELGESEL.tr.png" tvg-chno="146" channel-id="146",TRT Belgesel HD
 rtp://239.186.70.186:10000
-#EXTINF:-1 tvg-id="TRTCocuk.tr@SD" tvg-name="TRT COCUK TR" tvg-logo="https://static.epg.best/tr/TRTCOCUK.tr.png" tvg-chno="147" channel-id="147",TRT COCUK HD
+#EXTINF:-1 tvg-id="TRTCocuk.tr@SD" tvg-name="TRT Çocuk" tvg-logo="https://static.epg.best/tr/TRTCOCUK.tr.png" tvg-chno="147" channel-id="147",TRT COCUK HD
 rtp://239.186.70.185:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI HD
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdi" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI HD
 rtp://239.186.84.14:10000
-#EXTINF:-1 tvg-id="TRTSpor.tr@SD" tvg-name="TRT SPOR TR" tvg-logo="https://static.epg.best/tr/TRTSPOR.tr.png" tvg-chno="148" channel-id="148",TRT SPOR HD
+#EXTINF:-1 tvg-id="TRTSpor.tr@SD" tvg-name="TRT Spor" tvg-logo="https://static.epg.best/tr/TRTSPOR.tr.png" tvg-chno="148" channel-id="148",TRT SPOR HD
 rtp://239.186.70.187:10000
-#EXTINF:-1 tvg-id="TRTMuzik.tr@SD" tvg-name="TRT musik TR" tvg-logo="https://static.epg.best/tr/TRTMUSIK.tr.png" tvg-chno="149" channel-id="149",TRT musik HD
+#EXTINF:-1 tvg-id="TRTMuzik.tr@SD" tvg-name="TRT Müzik" tvg-logo="https://static.epg.best/tr/TRTMUSIK.tr.png" tvg-chno="149" channel-id="149",TRT musik HD
 rtp://239.186.70.198:10000
-#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNNTurk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
+#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNN Türk" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
 rtp://239.186.74.75:10000
-#EXTINF:-1 tvg-id="TV8int.tr@SD" tvg-name="TV8int TR" tvg-logo="https://static.epg.best/tr/TV8int.tr.png" tvg-chno="" channel-id="",TV8int HD (tur)
+#EXTINF:-1 tvg-id="TV8int.tr@SD" tvg-name="TV8 Int." tvg-logo="https://static.epg.best/tr/TV8int.tr.png" tvg-chno="" channel-id="",TV8int HD (tur)
 rtp://239.186.70.44:10000
 #EXTREM:others foreign language not listed above
-#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA HD
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA HD
 rtp://239.186.70.205:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD HD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD HD
 rtp://239.186.68.47:10000
-#EXTINF:-1 tvg-id="M1.hu@SD" tvg-name="M1 HU" tvg-logo="https://static.epg.best/hu/M1.hu.png" tvg-chno="156" channel-id="156",M1 HD
+#EXTINF:-1 tvg-id="M1.hu@SD" tvg-name="M1" tvg-logo="https://static.epg.best/hu/M1.hu.png" tvg-chno="156" channel-id="156",M1 HD
 rtp://239.186.70.206:10000
-#EXTINF:-1 tvg-id="M2.hu@SD" tvg-name="M2 HU" tvg-logo="https://static.epg.best/hu/M2.hu.png" tvg-chno="157" channel-id="157",M2 HD
+#EXTINF:-1 tvg-id="M2.hu@SD" tvg-name="M2" tvg-logo="https://static.epg.best/hu/M2.hu.png" tvg-chno="157" channel-id="157",M2 HD
 rtp://239.186.70.207:10000
-#EXTINF:-1 tvg-id="M5.hu@SD" tvg-name="M5 HU" tvg-logo="https://static.epg.best/hu/M5.hu.png" tvg-chno="159" channel-id="159",M5 HD
+#EXTINF:-1 tvg-id="M5.hu@SD" tvg-name="M5" tvg-logo="https://static.epg.best/hu/M5.hu.png" tvg-chno="159" channel-id="159",M5 HD
 rtp://239.186.70.209:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA HD
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA HD
 rtp://239.186.84.96:10000
-#EXTINF:-1 tvg-id="2066" tvg-name="TVP info PL" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
+#EXTINF:-1 tvg-id="" tvg-name="TVP info PL" tvg-logo="https://static.epg.best/pl/TVPinfo.pl.png" tvg-chno="464" channel-id="464",TVP INFO HD (pol)
 rtp://239.186.84.151:10000
-#EXTINF:-1 tvg-id="902" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
+#EXTINF:-1 tvg-id="" tvg-name="Epic Drama PL" tvg-logo="https://static.epg.best/pl/EpicDrama.hu.png" tvg-chno="" channel-id="",EPIC DRAMA HD (pol)
 rtp://239.186.70.99:10000
-#EXTINF:-1 tvg-id="1919" ,YKPAÏHA 24 / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="" ,YKPAÏHA 24 / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 tvg-id="EspresoTV.ua@SD",Espreso TV HD (ukr)
 rtp://239.186.84.176:10000
-#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="ElWatania1.tn@SD" tvg-name="Tunisie Nationale TN" tvg-logo="https://static.epg.best/tn/tunisienationale.tn.png" tvg-chno="153" channel-id="153",Tunisie Nationale
+#EXTINF:-1 tvg-id="ElWatania1.tn@SD" tvg-name="Tunisie Nationale" tvg-logo="https://static.epg.best/tn/tunisienationale.tn.png" tvg-chno="153" channel-id="153",Tunisie Nationale
 rtp://239.186.74.89:10000
-#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN TV" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV4" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="436" channel-id="436",CCTV4 HD
 rtp://239.186.70.89:10000
-#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="DM SAT SR" tvg-logo="https://static.epg.best/sr/DMsat.sr.png" tvg-chno="439" channel-id="439",DM Sat
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="DM Sat TV" tvg-logo="https://static.epg.best/sr/DMsat.sr.png" tvg-chno="439" channel-id="439",DM Sat
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",Dubai international TV HD
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",Dubai international TV HD
 rtp://239.186.70.246:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="https://static.epg.best/ca/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT cosmos HD
 rtp://239.186.70.80:10000
-#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT1 HR" tvg-logo="https://static.epg.best/hr/HRT1.hr" tvg-chno="446" channel-id="446",HRT1 HD
+#EXTINF:-1 tvg-id="HRT1.hr@SD" tvg-name="HRT 1" tvg-logo="https://static.epg.best/hr/HRT1.hr" tvg-chno="446" channel-id="446",HRT1 HD
 rtp://239.186.70.183:10000
-#EXTINF:-1 tvg-id="HRTInternational.hr@SD" tvg-name="HRTint HR" tvg-logo="https://static.epg.best/hr/HRTint.hr" tvg-chno="446" channel-id="446",HRT int HD
+#EXTINF:-1 tvg-id="HRTInternational.hr@SD" tvg-name="HRT Int." tvg-logo="https://static.epg.best/hr/HRTint.hr" tvg-chno="446" channel-id="446",HRT int HD
 rtp://239.186.70.153:10000
-#EXTINF:-1 tvg-id="2069" tvg-name="HRT4 HR" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
+#EXTINF:-1 tvg-id="" tvg-name="HRT4 HR" tvg-logo="https://static.epg.best/hr/HRT4.hr" tvg-chno="" channel-id="",HRT4 HD
 rtp://239.186.84.145:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="https://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="KurdistanTV IQ" tvg-logo="https://static.epg.best/iq/Kurdistantv.iq.png" tvg-chno="449" channel-id="449",Kurdistan TV
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="Kurdistan TV" tvg-logo="https://static.epg.best/iq/Kurdistantv.iq.png" tvg-chno="449" channel-id="449",Kurdistan TV
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="phoenix news CN" tvg-logo="https://static.epg.best/cn/phoenixnews.cn.png" tvg-chno="451" channel-id="451",PHOENIX NEWS Taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="https://static.epg.best/cn/phoenixnews.cn.png" tvg-chno="451" channel-id="451",PHOENIX NEWS Taiwan
 rtp://239.186.66.132:10000
-#EXTINF:-1 tvg-id="RTRPlanetaEurope.ru@SD" tvg-name="RTRPlaneta RU" tvg-logo="https://static.epg.best/ru/rtrplaneta.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
+#EXTINF:-1 tvg-id="RTRPlanetaEurope.ru@SD" tvg-name="RTR Planeta" tvg-logo="https://static.epg.best/ru/rtrplaneta.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1 SAT
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="460" channel-id="460",Rudaw TV HD (kur)
+#EXTINF:-1 tvg-id="RudawTV.iq@SD" tvg-name="Rudaw TV" tvg-logo="" tvg-chno="460" channel-id="460",Rudaw TV HD (kur)
 rtp://239.186.68.247:10000
-#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV
 rtp://239.186.66.135:10000
-#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="TVRomania RO" tvg-logo="https://static.epg.best/ro/tvri.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="TV Romania International" tvg-logo="https://static.epg.best/ro/tvri.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
 #EXTINF:-1 tvg-id="ptccbet.rs" tvg-name="PTC CBET RS" tvg-logo="https://static.epg.best/rs/ptccbet.rs.png" tvg-chno="473" channel-id="473",PTC CBET HD
 rtp://239.186.70.164:10000
-#EXTINF:-1 tvg-id="KBSWorld.kr@SD" tvg-name="KBS World KR" tvg-logo="https://static.epg.best/kr/KBSWorld.kr.png" tvg-chno="160" channel-id="160",KBS World HD
+#EXTINF:-1 tvg-id="KBSWorld.kr@SD" tvg-name="KBS World" tvg-logo="https://static.epg.best/kr/KBSWorld.kr.png" tvg-chno="160" channel-id="160",KBS World HD
 rtp://239.186.70.191:10000
-#EXTINF:-1 tvg-id="CT24.cz@SD" tvg-name="CT24 CZ" tvg-logo="https://static.epg.best/cz/CT24.cz.png" tvg-chno="" channel-id="",CT24 HD
+#EXTINF:-1 tvg-id="CT24.cz@SD" tvg-name="CT24" tvg-logo="https://static.epg.best/cz/CT24.cz.png" tvg-chno="" channel-id="",CT24 HD
 rtp://239.186.70.18:10000
-#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al arabiya HD (ara)
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al arabiya HD (ara)
 rtp://239.186.84.11:10000
-#EXTINF:-1 tvg-id="BNMusic.ba@SD" ,bn music HD (bos)
+#EXTINF:-1 tvg-id="BNMusic.ba@SD"  tvg-name="BN Music",bn music HD (bos)
 rtp://239.186.84.34:10000
-#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD" ,TV Duga+ (bos)
+#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD"  tvg-name="TV Duga+",TV Duga+ (bos)
 rtp://239.186.74.77:10000
 #EXTINF:-1 ,Diaspora Swiss TV HD
 rtp://239.186.84.107:10000
 #EXTINF:-1 tvg-id="Adria.si" tvg-name="Adria SI" tvg-logo="https://static.epg.best/si/adria.si.png" tvg-chno="" channel-id="",ADRIA Music Television HD (svn)
 rtp://239.186.68.184:10000
-#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasria.eg.png" tvg-chno="" channel-id="",Al Masriya HD (ara)
+#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya" tvg-logo="https://static.epg.best/eg/Almasria.eg.png" tvg-chno="" channel-id="",Al Masriya HD (ara)
 rtp://239.186.70.13:10000
-#EXTINF:-1 tvg-id="614",TOP NEWS HD (alb)
+#EXTINF:-1 tvg-id="",TOP NEWS HD (alb)
 rtp://239.186.84.144:10000
 #EXTINF:-1 tvg-id="24.sk@SD" ,rtv24 (slo)
 rtp://239.186.84.149:10000
@@ -772,11 +772,11 @@ rtp://239.186.84.155:10000
 rtp://239.186.84.161:10000
 #EXTINF:-1 ,ENTER FILM HD (ukr)
 rtp://239.186.84.163:10000
-#EXTINF:-1 tvg-id="ntv.de@SD" ,n HD (ukr)
+#EXTINF:-1 tvg-id="ntv.de@SD"  tvg-name="n-tv",n HD (ukr)
 rtp://239.186.84.167:10000
 #EXTINF:-1 ,BOYAH HD (ell)
 rtp://239.186.84.170:10000
-#EXTINF:-1 tvg-id="371" ,RTVI (rus)
+#EXTINF:-1 tvg-id=""  tvg-name="RTVi",RTVI (rus)
 rtp://239.186.74.2:10000
-#EXTINF:-1tvg-id="1727" ,Info Channel HD
+#EXTINF:-1tvg-id="" ,Info Channel HD
 rtp://239.186.70.168:10000

--- a/swisscom-hd.m3u
+++ b/swisscom-hd.m3u
@@ -59,7 +59,7 @@ rtp://239.186.70.148:10000
 rtp://239.186.70.125:10000
 #EXTINF:-1 tvg-id="i24NEWSFrench.il@SD" tvg-name="" tvg-logo="https://static.epg.best/il/i24news.il.png" tvg-chno="67" channel-id="67",i24 NEWS F HD
 rtp://239.186.70.102:10000
-#EXTINF:-1 tvg-id="icitv.ch" tvg-name="icitv CH" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
+#EXTINF:-1 tvg-id="GrandGeneveTV.fr@SD" tvg-name="icitv CH" tvg-logo="https://static.epg.best/ch/icitv.ch.png" tvg-chno="71" channel-id="71",ici tv HD
 rtp://239.186.70.133:10000
 #EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/latele.ch.png" tvg-chno="73" channel-id="73",LA TELE HD
 rtp://239.186.68.107:10000
@@ -526,7 +526,7 @@ rtp://239.186.70.6:10000
 rtp://239.186.68.163:10000
 #EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="376" channel-id="376",MEDIASET ITALIA1 HD
 rtp://239.186.68.165:10000
-#EXTINF:-1 tvg-id="ReteQuattro.it" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4 HD
+#EXTINF:-1 tvg-id="Rete4.it@SD" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4 HD
 rtp://239.186.70.188:10000
 #EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20Mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET HD
 rtp://239.186.68.46:10000
@@ -704,7 +704,7 @@ rtp://239.186.84.151:10000
 rtp://239.186.70.99:10000
 #EXTINF:-1 tvg-id="1919" ,YKPAÏHA 24 / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
-#EXTINF:-1 ,Espreso TV HD (ukr)
+#EXTINF:-1 tvg-id="EspresoTV.ua@SD",Espreso TV HD (ukr)
 rtp://239.186.84.176:10000
 #EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M Maroc
 rtp://239.186.64.194:10000
@@ -754,19 +754,19 @@ rtp://239.186.84.11:10000
 rtp://239.186.84.34:10000
 #EXTINF:-1 tvg-id="TVDugaPlus.rs@SD" ,TV Duga+ (bos)
 rtp://239.186.74.77:10000
-#EXTINF:-1 tvg-id="OraTV.al@SD" ,Diaspora Swiss TV HD
+#EXTINF:-1 ,Diaspora Swiss TV HD
 rtp://239.186.84.107:10000
 #EXTINF:-1 tvg-id="Adria.si" tvg-name="Adria SI" tvg-logo="https://static.epg.best/si/adria.si.png" tvg-chno="" channel-id="",ADRIA Music Television HD (svn)
 rtp://239.186.68.184:10000
 #EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasria.eg.png" tvg-chno="" channel-id="",Al Masriya HD (ara)
 rtp://239.186.70.13:10000
-#EXTINF:-1 tvg-id="614" ,TOP NEWS HD (alb)
+#EXTINF:-1 tvg-id="614",TOP NEWS HD (alb)
 rtp://239.186.84.144:10000
-#EXTINF:-1 tvg-id="1910" ,rtv24 (slo)
+#EXTINF:-1 tvg-id="24.sk@SD" ,rtv24 (slo)
 rtp://239.186.84.149:10000
 #EXTINF:-1 ,mne HD (srp)
 rtp://239.186.84.154:10000
-#EXTINF:-1 tvg-id="RTS2.ch@SD" ,RTSH24 HD (alb)
+#EXTINF:-1 tvg-id="RTSH24.al@SD" ,RTSH24 HD (alb)
 rtp://239.186.84.155:10000
 #EXTINF:-1 ,nikceabtv HD (ukr)
 rtp://239.186.84.161:10000

--- a/swisscom-sd.m3u
+++ b/swisscom-sd.m3u
@@ -75,13 +75,13 @@ rtp://239.186.64.145:10000
 rtp://239.186.64.69:10000
 #EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="107" channel-id="107",TV5MONDE EUROPE
 rtp://239.186.64.71:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBSM" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
 rtp://239.186.64.150:10000
 #EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="https://static.epg.best/ch/TVM3.ch.png" tvg-chno="110" channel-id="110",tvm3
 rtp://239.186.64.98:10000
 #EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="111" channel-id="111",6ter
 rtp://239.186.66.130:10000
-#EXTINF:-1 tvg-id="ORTBTV.bj@SD" tvg-name="ORTB" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
+#EXTINF:-1 tvg-id="ORTBTV.bj@SD" tvg-name="Benin TV" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
 rtp://239.186.74.97:10000
 #EXTREM:english
 #EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/gb/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC ONE
@@ -164,17 +164,17 @@ rtp://239.186.74.84:10000
 rtp://239.186.74.87:10000
 #EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Pick" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
+#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Sky Mix" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
 rtp://239.186.74.94:10000
 #EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
-#EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/truecrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME UK
+#EXTINF:-1 tvg-id="CBSRealityEMEA.uk@SD" tvg-name="True Crime" tvg-logo="https://static.epg.best/gb/truecrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME UK
 rtp://239.186.74.107:10000
 #EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance" tvg-logo="https://static.epg.best/gb/GreatRomance.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
 #EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Action" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
 rtp://239.186.74.58:10000
-#EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/GreatMystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
+#EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery" tvg-logo="https://static.epg.best/gb/GreatMystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
 #EXTREM:german
 #EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
@@ -189,7 +189,7 @@ rtp://239.186.64.55:10000
 rtp://239.186.64.56:10000
 #EXTINF:-1 tvg-id="4Plus.ch@SD" tvg-name="4+" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
 rtp://239.186.64.142:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AW1 TV
+#EXTINF:-1 tvg-id="AlpenlandTV.ch@SD" tvg-name="AW1 TV" tvg-logo="" tvg-chno="179" channel-id="179",AW1 TV
 rtp://239.186.64.112:10000
 #EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="182" channel-id="182",ARD Das Erste
 rtp://239.186.64.11:10000
@@ -205,7 +205,7 @@ rtp://239.186.64.131:10000
 rtp://239.186.64.26:10000
 #EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="Helvetia One TV" tvg-logo="https://static.epg.best/ch/Helvetiaone.ch.png" tvg-chno="198" channel-id="198",HELVETIA ONE
 rtp://239.186.66.238:10000
-#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="DMF" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
 rtp://239.186.66.118:10000
 #EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel D" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
 rtp://239.186.64.116:10000
@@ -334,7 +334,7 @@ rtp://239.186.74.150:10000
 #EXTINF:-1 ,just.fishing (deu)
 rtp://239.186.74.157:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
 #EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
@@ -362,7 +362,7 @@ rtp://239.186.66.188:10000
 rtp://239.186.66.187:10000
 #EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros Discovery K2
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Discovery Turbo" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
 rtp://239.186.74.21:10000
 #EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros Discovery food network I
 rtp://239.186.66.122:10000
@@ -485,7 +485,7 @@ rtp://239.186.64.204:10000
 rtp://239.186.64.201:10000
 #EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show Türk" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
 rtp://239.186.64.200:10000
 #EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
@@ -520,7 +520,7 @@ rtp://239.186.74.52:10000
 rtp://239.186.66.85:10000
 #EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya" tvg-logo="https://static.epg.best/eg/Almasriya.eg.png" tvg-chno="443" channel-id="443",Al Masriya
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT Cosmos" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
 #EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="https://static.epg.best/hr/Htv1.hr.png" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
@@ -536,7 +536,7 @@ rtp://239.186.66.138:10000
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="https://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK 1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
 #EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
@@ -550,9 +550,9 @@ rtp://239.186.74.77:10000
 rtp://239.186.74.83:10000
 #EXTINF:-1 tvg-id="ElWatania1.tn@SD"  tvg-name="Tunisie Nationale",Tunisie Nationale (ara)
 rtp://239.186.74.89:10000
-#EXTINF:-1 tvg-id="" tvg-name="Freedom",YKPAÏHA 24  / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="" tvg-name="FreeDOM",YKPAÏHA 24  / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
-#EXTINF:-1 ,Espreso TV (ukr)
+#EXTINF:-1  tvg-name="Espreso TV",Espreso TV (ukr)
 rtp://239.186.74.158:10000
 #EXTINF:-1 tvg-id=""  tvg-name="1+1 Int.",1+1 int. (ukr)
 rtp://239.186.74.9:10000

--- a/swisscom-sd.m3u
+++ b/swisscom-sd.m3u
@@ -3,558 +3,558 @@
 #EXTEPG url-tvg=""
 #PLAYLIST: bluetv channel free open standard size 576i, codec video h.264 only on host Swisscom network or partners of multicast network
 #EXTREM:french
-#EXTINF:-1 tvg-id="BlueZoomF.ch" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="0" channel-id="0",blue zoom F
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="0" channel-id="0",blue zoom F
 rtp://239.186.64.111:10000
-#EXTINF:-1 tvg-id="C202.api.telerama.fr" tvg-name="RTS1" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS1
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS1" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS1
 rtp://239.186.64.5:10000
-#EXTINF:-1 tvg-id="C183.api.telerama.fr" tvg-name="RTS2" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS2
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS2" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS2
 rtp://239.186.64.6:10000
-#EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
+#EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
 rtp://239.186.64.35:10000
-#EXTINF:-1 tvg-id="France2.fr" tvg-name="France 2 FR" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
 rtp://239.186.64.36:10000
-#EXTINF:-1 tvg-id="France3.fr" tvg-name="France 3 FR" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
 rtp://239.186.64.37:10000
-#EXTINF:-1 tvg-id="France4.fr" tvg-name="France 4 FR" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 / culturebox
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 / culturebox
 rtp://239.186.64.38:10000
-#EXTINF:-1 tvg-id="France5" tvg-name="France 5 FR" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
 rtp://239.186.64.39:10000
-#EXTINF:-1 tvg-id="M6.fr" tvg-name="M6 FR" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
 rtp://239.186.64.40:10000
-#EXTINF:-1 tvg-id="TMC.fr" tvg-name="TMC FR" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
 rtp://239.186.64.127:10000
-#EXTINF:-1 tvg-id="NT1.fr" tvg-name="TFX FR" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH
 rtp://239.186.64.42:10000
-#EXTINF:-1 tvg-id="W9.fr" tvg-name="W9 FR" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
 rtp://239.186.66.24:10000
-#EXTINF:-1 tvg-id="Arte.fr" tvg-name="Arte FR" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
 rtp://239.186.64.57:10000
-#EXTINF:-1 tvg-id="AB3.fr" tvg-name="AB 3 FR" tvg-logo="https://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="https://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="8MontBlanc" tvg-name="8 Mont-Blanc FR" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
 rtp://239.186.64.144:10000
-#EXTINF:-1 tvg-id="BFMTV.fr" tvg-name="BFM TV FR" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
 rtp://239.186.64.72:10000
-#EXTINF:-1 tvg-id="carac4.ch" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="39" channel-id="39",carac4
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="39" channel-id="39",carac4
 rtp://239.186.66.239:10000
-#EXTINF:-1 tvg-id="Canal9.ch" tvg-name="Canal9 CH" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="42" channel-id="42",Canal9
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal9 CH" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="42" channel-id="42",Canal9
 rtp://239.186.64.108:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
 rtp://239.186.64.106:10000
-#EXTINF:-1 tvg-id="CanalAlpha.ch" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
 rtp://239.186.64.92:10000
-#EXTINF:-1 tvg-id="EuronewsF" tvg-name="Euronews FR" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
 rtp://239.186.64.151:10000
-#EXTINF:-1 tvg-id="FranceInfo.fr" tvg-name="France Info FR" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
 rtp://239.186.66.225:10000
-#EXTINF:-1 tvg-id="France24F" tvg-name="France 24 FR" tvg-logo="https://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="https://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
 rtp://239.186.64.41:10000
-#EXTINF:-1 tvg-id="Gulli.fr" tvg-name="Gulli FR" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
 rtp://239.186.66.23:10000
-#EXTINF:-1 tvg-id="i24News.fr" tvg-name="I24News FR" tvg-logo="https://static.epg.best/fr/i24news.fr.png" tvg-chno="66" channel-id="66",i24 NEWS F
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24News FR" tvg-logo="https://static.epg.best/fr/i24news.fr.png" tvg-chno="66" channel-id="66",i24 NEWS F
 rtp://239.186.66.174:10000
-#EXTINF:-1 tvg-id="CNews.fr" tvg-name="CNews FR" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
 rtp://239.186.66.25:10000
-#EXTINF:-1 tvg-id="KTO.fr" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="LaTele.ch" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/LaTele.ch.png" tvg-chno="72" channel-id="72",LA TELE
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/LaTele.ch.png" tvg-chno="72" channel-id="72",LA TELE
 rtp://239.186.64.104:10000
-#EXTINF:-1 tvg-id="LCI.fr" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="75" channel-id="75",lemanbleu
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="75" channel-id="75",lemanbleu
 rtp://239.186.64.89:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv/DieuTV
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv/DieuTV
 rtp://239.186.64.102:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
 rtp://239.186.66.198:10000
-#EXTINF:-1 tvg-id="TeleBielingue.ch" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="302" channel-id="302",TeleBielingue
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="302" channel-id="302",TeleBielingue
 rtp://239.186.64.95:10000
-#EXTINF:-1 tvg-id="carac1.ch" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="88" channel-id="88",carac1
+#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="88" channel-id="88",carac1
 rtp://239.186.64.145:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="95" channel-id="95",GRTV Genève Region TV
 rtp://239.186.64.69:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr" tvg-name="TV 5 Monde Europe FR" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="107" channel-id="107",TV5MONDE EUROPE
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="107" channel-id="107",TV5MONDE EUROPE
 rtp://239.186.64.71:10000
-#EXTINF:-1 tvg-id="TV5MONDE" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
 rtp://239.186.64.150:10000
-#EXTINF:-1 tvg-id="tvm3.ch" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/TVM3.ch.png" tvg-chno="110" channel-id="110",tvm3
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/TVM3.ch.png" tvg-chno="110" channel-id="110",tvm3
 rtp://239.186.64.98:10000
-#EXTINF:-1 tvg-id="6ter.fr" tvg-name="6ter FR" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="111" channel-id="111",6ter
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="111" channel-id="111",6ter
 rtp://239.186.66.130:10000
-#EXTINF:-1 tvg-id="ortb.bj" tvg-name="ortb BJ" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
+#EXTINF:-1 tvg-id="ORTBTV.bj@SD" tvg-name="ortb BJ" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
 rtp://239.186.74.97:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="BBC1.uk" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/gb/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC ONE
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/gb/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC ONE
 rtp://239.186.64.51:10000
-#EXTINF:-1 tvg-id="BBC2.uk" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/gb/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC TWO
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/gb/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC TWO
 rtp://239.186.64.165:10000
-#EXTINF:-1 tvg-id="CBBC.uk" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/gb/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC / BBC THREE
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/gb/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC / BBC THREE
 rtp://239.186.64.166:10000
-#EXTINF:-1 tvg-id="BBC4.uk" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
+#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
 rtp://239.186.64.52:10000
-#EXTINF:-1 tvg-id="CBeebies.uk" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/gb/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/gb/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
-#EXTINF:-1 tvg-id="BBCNews.uk" tvg-name="BBC NEWS UK" tvg-logo="https://static.epg.best/gb/BBCNews.uk.png" tvg-chno="129" channel-id="129",BBC NEWS (UK)
+#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC NEWS UK" tvg-logo="https://static.epg.best/gb/BBCNews.uk.png" tvg-chno="129" channel-id="129",BBC NEWS (UK)
 rtp://239.186.64.176:10000
-#EXTINF:-1 tvg-id="BloombergTV.uk" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/gb/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/gb/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
 rtp://239.186.64.177:10000
-#EXTINF:-1 tvg-id="CGTN.au" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN
 rtp://239.186.66.114:10000
-#EXTINF:-1 tvg-id="Channel4.uk" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/gb/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/gb/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
 rtp://239.186.64.183:10000
-#EXTINF:-1 tvg-id="Now70s.uk" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",NOW 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",NOW 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 tvg-id="Now80s.uk" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",NOW 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",NOW 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="NowRock.uk" tvg-name="Now Rock UK" tvg-logo="https://static.epg.best/gb/Nowrock.uk.png" tvg-chno="140" channel-id="140",NOW Rock
+#EXTINF:-1 tvg-id="NOWRock.uk@SD" tvg-name="Now Rock UK" tvg-logo="https://static.epg.best/gb/Nowrock.uk.png" tvg-chno="140" channel-id="140",NOW Rock
 rtp://239.186.66.133:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/gb/ClublandTV.uk.png" tvg-chno="141" channel-id="141",Clubland
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/gb/ClublandTV.uk.png" tvg-chno="141" channel-id="141",Clubland
 rtp://239.186.66.116:10000
-#EXTINF:-1 tvg-id="CNBC.uk" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/gb/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC EU
+#EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/gb/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC EU
 rtp://239.186.64.167:10000
-#EXTINF:-1 tvg-id="CNN.uk" tvg-name="CNN UK" tvg-logo="https://static.epg.best/gb/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="https://static.epg.best/gb/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
 rtp://239.186.64.175:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="207" channel-id="207",DEUTSCHE WELLE En
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="UandDrama.uk" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
+#EXTINF:-1 tvg-id="902" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
 rtp://239.186.66.140:10000
-#EXTINF:-1 tvg-id="E4.uk" tvg-name="E4 UK" tvg-logo="https://static.epg.best/gb/E4.uk.png" tvg-chno="147" channel-id="147",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="https://static.epg.best/gb/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuroNews.uk" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/gb/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews E
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/gb/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews E
 rtp://239.186.64.178:10000
-#EXTINF:-1 tvg-id="FashionTV.fr" tvg-name="Fashion TV FR" tvg-logo="https://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
+#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="https://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
 rtp://239.186.64.174:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="https://static.epg.best/uk/Film4.uk.png" tvg-chno="152" channel-id="152",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="channel5.uk" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="153" channel-id="153",Channel5
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="153" channel-id="153",Channel5
 rtp://239.186.64.184:10000
-#EXTINF:-1 tvg-id="FoodNetwork.uk" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/gb/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/gb/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="i24news.il" tvg-name="i24news IL" tvg-logo="https://static.epg.best/il/i24news.png" tvg-chno="157" channel-id="157",i24 NEWS E
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24news IL" tvg-logo="https://static.epg.best/il/i24news.png" tvg-chno="157" channel-id="157",i24 NEWS E
 rtp://239.186.66.126:10000
-#EXTINF:-1 tvg-id="ITV1.uk" tvg-name="ITV UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="159" channel-id="159",itv1
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="159" channel-id="159",itv1
 rtp://239.186.64.169:10000
-#EXTINF:-1 tvg-id="ITV2.uk" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
 rtp://239.186.64.170:10000
-#EXTINF:-1 tvg-id="ITV3.uk" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
 rtp://239.186.64.180:10000
-#EXTINF:-1 tvg-id="ITV4.uk" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
 rtp://239.186.64.171:10000
-#EXTINF:-1 tvg-id="More4.uk" tvg-name="More4 UK" tvg-logo="https://static.epg.best/gb/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="https://static.epg.best/gb/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="SkyNews.uk" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/gb/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news international
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/gb/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news international
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="FiveUSA.uk" tvg-name="5USA UK" tvg-logo="https://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA UK
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="https://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA UK
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk" tvg-name="BBCParliament uk" tvg-logo="https://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC PARLIAMENT
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBCParliament uk" tvg-logo="https://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC PARLIAMENT
 rtp://239.186.74.25:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America UK
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America UK
 rtp://239.186.66.243:10000
-#EXTINF:-1 tvg-id="UandDave.uk" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
+#EXTINF:-1 tvg-id="1507" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
 rtp://239.186.66.253:10000
-#EXTINF:-1 tvg-id="5Star.uk" tvg-name="5Star UK" tvg-logo="https://static.epg.best/gb/5star.uk.png" tvg-chno="" channel-id="",5STAR
+#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star UK" tvg-logo="https://static.epg.best/gb/5star.uk.png" tvg-chno="" channel-id="",5STAR
 rtp://239.186.74.72:10000
-#EXTINF:-1 tvg-id="5Select.uk" tvg-name="5Select UK" tvg-logo="https://static.epg.best/gb/5select.uk.png" tvg-chno="" channel-id="",5SELECT
+#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5Select UK" tvg-logo="https://static.epg.best/gb/5select.uk.png" tvg-chno="" channel-id="",5SELECT
 rtp://239.186.74.88:10000
-#EXTINF:-1 tvg-id="DiscoveryDMAX.uk" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/gb/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/gb/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
 rtp://239.186.74.74:10000
-#EXTINF:-1 tvg-id="5ACTION.uk" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/gb/5ACTION.uk.png" tvg-chno="" channel-id="",5ACTION
+#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/gb/5ACTION.uk.png" tvg-chno="" channel-id="",5ACTION
 rtp://239.186.74.84:10000
-#EXTINF:-1 tvg-id="UandYesterday.uk" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="1674" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
-#EXTINF:-1 tvg-id="4Seven.uk" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
+#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="skymix.uk" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
+#EXTINF:-1 tvg-id="2017" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
 rtp://239.186.74.94:10000
-#EXTINF:-1 tvg-id="Challenge.uk" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
+#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
 #EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/truecrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME UK
 rtp://239.186.74.107:10000
-#EXTINF:-1 tvg-id="GreatRomance.uk" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatRomance.uk.png" tvg-chno="" channel-id="",GREAT! romance
+#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatRomance.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
-#EXTINF:-1 tvg-id="GreatAction.uk" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
+#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
 rtp://239.186.74.58:10000
 #EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/GreatMystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="SRF1.ch" tvg-name="SF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
 rtp://239.186.64.2:10000
-#EXTINF:-1 tvg-id="SRF2.ch" tvg-name="SF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
 rtp://239.186.64.3:10000
-#EXTINF:-1 tvg-id="SRFInfo.ch" tvg-name="SF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
 rtp://239.186.64.4:10000
-#EXTINF:-1 tvg-id="3sat.at" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
+#EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
 rtp://239.186.64.55:10000
-#EXTINF:-1 tvg-id="3Plus.ch" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
+#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
 rtp://239.186.64.56:10000
-#EXTINF:-1 tvg-id="4Plus.ch" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
+#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
 rtp://239.186.64.142:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AW1 TV
 rtp://239.186.64.112:10000
-#EXTINF:-1 tvg-id="ARD.de" tvg-name="Das Erste DE" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="182" channel-id="182",ARD Das Erste
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste DE" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="182" channel-id="182",ARD Das Erste
 rtp://239.186.64.11:10000
-#EXTINF:-1 tvg-id="ARDalpha.de" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha
 rtp://239.186.64.119:10000
-#EXTINF:-1 tvg-id="One.de" tvg-name="One DE" tvg-logo="https://static.epg.best/de/One.de.png" tvg-chno="185" channel-id="185",ARD one
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One DE" tvg-logo="https://static.epg.best/de/One.de.png" tvg-chno="185" channel-id="185",ARD one
 rtp://239.186.64.121:10000
-#EXTINF:-1 tvg-id="ARTE.de" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="187" channel-id="187",arte D
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="187" channel-id="187",arte D
 rtp://239.186.64.23:10000
-#EXTINF:-1 tvg-id="BibelTV.de" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
 rtp://239.186.64.131:10000
-#EXTINF:-1 tvg-id="BR.de" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
 rtp://239.186.64.26:10000
-#EXTINF:-1 tvg-id="helvetiaone.ch" tvg-name="Helvetia One CH" tvg-logo="https://static.epg.best/ch/Helvetiaone.ch.png" tvg-chno="198" channel-id="198",HELVETIA ONE
+#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="Helvetia One CH" tvg-logo="https://static.epg.best/ch/Helvetiaone.ch.png" tvg-chno="198" channel-id="198",HELVETIA ONE
 rtp://239.186.66.238:10000
-#EXTINF:-1 tvg-id="DeutschesMusikFernsehen.de" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
 rtp://239.186.66.118:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="RiC.de" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",RiC
+#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",RiC
 rtp://239.186.64.129:10000
-#EXTINF:-1 tvg-id="Euronews.de" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
 rtp://239.186.64.137:10000
-#EXTINF:-1 tvg-id="HopeChannelInt.de" tvg-name="Hope Channel Int. DE" tvg-logo="https://static.epg.best/de/HopeChannelInt.de.png" tvg-chno="214" channel-id="214",HopeTV
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. DE" tvg-logo="https://static.epg.best/de/HopeChannelInt.de.png" tvg-chno="214" channel-id="214",HopeTV
 rtp://239.186.64.115:10000
-#EXTINF:-1 tvg-id="HR.de" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
 rtp://239.186.64.28:10000
-#EXTINF:-1 tvg-id="HSE.de" tvg-name="HSE DE" tvg-logo="https://static.epg.best/de/HSE.de.png" tvg-chno="218" channel-id="218",HSE
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE DE" tvg-logo="https://static.epg.best/de/HSE.de.png" tvg-chno="218" channel-id="218",HSE
 rtp://239.186.64.123:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins
 rtp://239.186.64.20:10000
-#EXTINF:-1 tvg-id="Kanal9.ch" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
 rtp://239.186.64.109:10000
-#EXTINF:-1 tvg-id="Kika.de" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
 rtp://239.186.64.31:10000
-#EXTINF:-1 tvg-id="KTV.de" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
+#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
 rtp://239.186.64.133:10000
-#EXTINF:-1 tvg-id="Loly.ch" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY
 rtp://239.186.66.231:10000
-#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie.tv
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="N24Doku.de" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
-#EXTINF:-1 tvg-id="7plus.ch" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="238" channel-id="238",7+
+#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="238" channel-id="238",7+
 rtp://239.186.64.186:10000
-#EXTINF:-1 tvg-id="RTLNitro.de" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
-#EXTINF:-1 tvg-id="ntv.de" tvg-name="n-tv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
 rtp://239.186.64.29:10000
-#EXTINF:-1 tvg-id="ORF1.at" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="244" channel-id="244",ORF1
+#EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="244" channel-id="244",ORF1
 rtp://239.186.64.13:10000
-#EXTINF:-1 tvg-id="ORF2.at" tvg-name="ORF 2" tvg-logo="https://static.epg.best/at/ORF2.at.png" tvg-chno="246" channel-id="246",ORF2
+#EXTINF:-1 tvg-id="ORF2.at@SD" tvg-name="ORF 2" tvg-logo="https://static.epg.best/at/ORF2.at.png" tvg-chno="246" channel-id="246",ORF2
 rtp://239.186.64.14:10000
-#EXTINF:-1 tvg-id="ORF3.at" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3
+#EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3
 rtp://239.186.64.86:10000
-#EXTINF:-1 tvg-id="Phoenix.de" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
 rtp://239.186.64.65:10000
-#EXTINF:-1 tvg-id="ProSieben.de" tvg-name="Pro 7 DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro 7 DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben
 rtp://239.186.64.19:10000
-#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
+#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
 rtp://239.186.64.126:10000
-#EXTINF:-1 tvg-id="RTL.de" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="RTL2.de" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
+#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="RTLup.de" tvg-name="RTL Up DE" tvg-logo="https://static.epg.best/de/RTLUp.de.png" tvg-chno="262" channel-id="262",RTLup
+#EXTINF:-1 tvg-id="RTLup.de@SD" tvg-name="RTL Up DE" tvg-logo="https://static.epg.best/de/RTLUp.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="Sat1.de" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
 rtp://239.186.64.18:10000
-#EXTINF:-1 tvg-id="ServusTV.at" tvg-name="Servus TV" tvg-logo="https://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV
+#EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="https://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV
 rtp://239.186.64.136:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
+#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
 rtp://239.186.66.146:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="273" channel-id="273",SessionStaenderat
 rtp://239.186.64.124:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
 rtp://239.186.64.97:10000
-#EXTINF:-1 tvg-id="sixx.de" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
 rtp://239.186.64.70:10000
-#EXTINF:-1 tvg-id="Sport1.de" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",Sport1 CH
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",Sport1 CH
 rtp://239.186.64.64:10000
-#EXTINF:-1 tvg-id="StarTV.ch" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
 rtp://239.186.64.87:10000
-#EXTINF:-1 tvg-id="RTLsuper.de" tvg-name="RTL Super DE" tvg-logo="https://static.epg.best/de/RTLsuper.de.png" tvg-chno="290" channel-id="290",RTL SUPER
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="RTL Super DE" tvg-logo="https://static.epg.best/de/RTLsuper.de.png" tvg-chno="290" channel-id="290",RTL SUPER
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="SWRSR.de" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >>
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >>
 rtp://239.186.64.27:10000
-#EXTINF:-1 tvg-id="Tagesschau24.de" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24
 rtp://239.186.64.120:10000
-#EXTINF:-1 tvg-id="Tele1.ch" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1
 rtp://239.186.64.91:10000
-#EXTINF:-1 tvg-id="TeleBaern.ch" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",tele baern
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",tele baern
 rtp://239.186.64.60:10000
-#EXTINF:-1 tvg-id="TeleM1.ch" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
 rtp://239.186.64.90:10000
-#EXTINF:-1 tvg-id="TeleTop.ch" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
 rtp://239.186.64.96:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
 rtp://239.186.64.103:10000
-#EXTINF:-1 tvg-id="TeleZueri.ch" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",Tele Zuri
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",Tele Zuri
 rtp://239.186.64.9:10000
-#EXTINF:-1 tvg-id="TeleBasel.ch" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
 rtp://239.186.64.88:10000
-#EXTINF:-1 tvg-id="BlueZoomD.ch" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="316" channel-id="316",blue zoom D
+#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="316" channel-id="316",blue zoom D
 rtp://239.186.66.129:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="321" channel-id="321",TSO
 rtp://239.186.64.100:10000
-#EXTINF:-1 tvg-id="TVO.ch" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
 rtp://239.186.64.94:10000
-#EXTINF:-1 tvg-id="Vox.de" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
-#EXTINF:-1 tvg-id="Welt.de" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="ZDF.de" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
 rtp://239.186.64.12:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
 rtp://239.186.64.118:10000
-#EXTINF:-1 tvg-id="ZDFneo.de" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
 rtp://239.186.64.66:10000
-#EXTINF:-1 tvg-id="HGTV.de" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="" channel-id="",HGTV DE
+#EXTINF:-1 tvg-id="95" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="" channel-id="",HGTV DE
 rtp://239.186.74.40:10000
-#EXTINF:-1 tvg-id="VOXup.de" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="" channel-id="",VOXup
+#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="" channel-id="",VOXup
 rtp://239.186.74.70:10000
-#EXTINF:-1 tvg-id="schlagerdeluxe.de" tvg-name="schlager deluxe DE" tvg-logo="https://static.epg.best/de/schlagerdeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
+#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="schlager deluxe DE" tvg-logo="https://static.epg.best/de/schlagerdeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
 rtp://239.186.74.105:10000
-#EXTINF:-1 tvg-id="volksmusik.de" tvg-name="volksmusik DE" tvg-logo="https://static.epg.best/de/volksmusik.de.png" tvg-chno="" channel-id="",volksmusik.tv
+#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="volksmusik DE" tvg-logo="https://static.epg.best/de/volksmusik.de.png" tvg-chno="" channel-id="",volksmusik.tv
 rtp://239.186.74.113:10000
-#EXTINF:-1 tvg-id="morethansports.de" tvg-name="More Than Sports DE" tvg-logo="https://static.epg.best/de/morethansports.de.png" tvg-chno="205" channel-id="205",More Than Sports D
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="More Than Sports DE" tvg-logo="https://static.epg.best/de/morethansports.de.png" tvg-chno="205" channel-id="205",More Than Sports D
 rtp://239.186.66.241:10000
-#EXTINF:-1 ,stimmungsgarten.tv (deu)
+#EXTINF:-1 tvg-id="2055" ,stimmungsgarten.tv (deu)
 rtp://239.186.74.148:10000
-#EXTINF:-1 ,justcooking.tv (deu)
+#EXTINF:-1 tvg-id="2041" ,justcooking.tv (deu)
 rtp://239.186.74.150:10000
 #EXTINF:-1 ,just.fishing (deu)
 rtp://239.186.74.157:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILA1.ch" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
-#EXTINF:-1 tvg-id="RSILA2.ch" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="346" channel-id="346",7G Telecity
 rtp://239.186.74.23:10000
-#EXTINF:-1 tvg-id="Almatv.it" tvg-name="	Almatv IT" tvg-logo="https://static.epg.best/it/Almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
+#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="	Almatv IT" tvg-logo="https://static.epg.best/it/Almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
 rtp://239.186.74.18:10000
-#EXTINF:-1 tvg-id="Boing.it" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
 rtp://239.186.64.74:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Cartoonito.it" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",Cartoonito
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",Cartoonito
 rtp://239.186.66.176:10000
-#EXTINF:-1 tvg-id="Cielo.it" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
 rtp://239.186.64.76:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",ClassTV Moda
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",ClassTV Moda
 rtp://239.186.66.189:10000
-#EXTINF:-1 tvg-id="DMAX.it" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros Discovery DMAX
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros Discovery DMAX
 rtp://239.186.66.110:10000
-#EXTINF:-1 tvg-id="Frisbee.it" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros Discovery FRISBEE
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros Discovery FRISBEE
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="Giallo.it" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros Discovery Giallo
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros Discovery Giallo
 rtp://239.186.66.187:10000
-#EXTINF:-1 tvg-id="K2.it" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros Discovery K2
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros Discovery K2
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="MotorTrend.it" tvg-name="Motor Trend IT" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend IT" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
 rtp://239.186.74.21:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros Discovery food network I
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros Discovery food network I
 rtp://239.186.66.122:10000
-#EXTINF:-1 tvg-id="NOVE.it" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Warner Bros Discovery NOVE
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Warner Bros Discovery NOVE
 rtp://239.186.64.158:10000
-#EXTINF:-1 tvg-id="RealTime.it" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros Discovery Real Time
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros Discovery Real Time
 rtp://239.186.66.43:10000
-#EXTINF:-1 tvg-id="Euronews.it" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL 123
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL 123
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="La7.it" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
 rtp://239.186.64.49:10000
-#EXTINF:-1 tvg-id="La7cinama.it" tvg-name="La7cinema IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7cinema IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA
 rtp://239.186.64.164:10000
-#EXTINF:-1 tvg-id="20mediaset.it" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET
 rtp://239.186.74.67:10000
-#EXTINF:-1 tvg-id="Canale5.it" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
 rtp://239.186.64.46:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
 rtp://239.186.66.37:10000
-#EXTINF:-1 tvg-id="FocusTv.it" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
 rtp://239.186.66.69:10000
-#EXTINF:-1 tvg-id="Italia1.it" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
 rtp://239.186.64.48:10000
-#EXTINF:-1 tvg-id="Italia2.it" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
 rtp://239.186.66.44:10000
-#EXTINF:-1 tvg-id="Iris.it" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
 rtp://239.186.64.75:10000
-#EXTINF:-1 tvg-id="La5.it" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
 rtp://239.186.64.73:10000
 #EXTINF:-1 tvg-id="ReteQuattro.it" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4
 rtp://239.186.64.47:10000
-#EXTINF:-1 tvg-id="Tgcom24.it" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
 rtp://239.186.64.214:10000
-#EXTINF:-1 tvg-id="TopCrime.it" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
 rtp://239.186.66.180:10000
-#EXTINF:-1 tvg-id="Cine34.it" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34
+#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34
 rtp://239.186.74.78:10000
-#EXTINF:-1 tvg-id="radionorba.it" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="" channel-id="",radionorba TV
+#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="" channel-id="",radionorba TV
 rtp://239.186.66.247:10000
-#EXTINF:-1 tvg-id="RaiUno.it" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
 rtp://239.186.64.43:10000
-#EXTINF:-1 tvg-id="RaiDue.it" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
 rtp://239.186.64.44:10000
-#EXTINF:-1 tvg-id="RaiTre.it" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
 rtp://239.186.64.45:10000
-#EXTINF:-1 tvg-id="Rai4.it" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
 rtp://239.186.64.50:10000
-#EXTINF:-1 tvg-id="Rai5.it" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiGulp.it" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
 rtp://239.186.66.35:10000
-#EXTINF:-1 tvg-id="RaiMovie.it" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
 rtp://239.186.66.185:10000
-#EXTINF:-1 tvg-id="RaiNews.it" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
 rtp://239.186.64.156:10000
-#EXTINF:-1 tvg-id="RaiPremium.it" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
 rtp://239.186.66.183:10000
-#EXTINF:-1 tvg-id="RaiScuola.it" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
 rtp://239.186.66.34:10000
-#EXTINF:-1 tvg-id="RaiSportPlus.it" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport
 rtp://239.186.64.157:10000
-#EXTINF:-1 tvg-id="RaiStoria.it" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
 rtp://239.186.64.162:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="SkyTG24.it" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
 rtp://239.186.66.177:10000
-#EXTINF:-1 tvg-id="Sportitalia.it" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sportitalia plus
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sportitalia plus
 rtp://239.186.74.24:10000
-#EXTINF:-1 tvg-id="Super.it" tvg-name="Super IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="teleticino.ch" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="410" channel-id="410",teleticino
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="410" channel-id="410",teleticino
 rtp://239.186.64.99:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
 rtp://239.186.64.154:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
 rtp://239.186.64.152:10000
-#EXTINF:-1 tvg-id="TV8.it" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
 rtp://239.186.64.161:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO.TV
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO.TV
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="TV2000.it" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000
 rtp://239.186.66.108:10000
-#EXTINF:-1 tvg-id="Espansione.it" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/espansione.it.png",Espansione TV
+#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/espansione.it.png",Espansione TV
 rtp://239.186.74.22:10000
-#EXTINF:-1 tvg-id="HGTV.it" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
+#EXTINF:-1 tvg-id="95" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
 rtp://239.186.74.71:10000
-#EXTINF:-1 tvg-id="discovery.it" tvg-name="discovery IT" tvg-logo="http://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I
+#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="discovery IT" tvg-logo="http://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I
 rtp://239.186.64.191:10000
-#EXTINF:-1 ,TOP CALCIO 24
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" ,TOP CALCIO 24
 rtp://239.186.74.79:10000
-#EXTINF:-1 ,senato italiano tv
+#EXTINF:-1 tvg-id="SenatoTV.it@SD" ,senato italiano tv
 rtp://239.186.74.85:10000
-#EXTINF:-1 ,camera dei deputati
+#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD" ,camera dei deputati
 rtp://239.186.74.59:10000
-#EXTINF:-1 tvg-id="twentyseven.it" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 italian
+#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 italian
 rtp://239.186.74.114:10000
 #EXTREM:portuguese
-#EXTINF:-1 tvg-id="RecordTV.br" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record TV
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record TV
 rtp://239.186.64.83:10000
-#EXTINF:-1 tvg-id="RTPInternacional.pt" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
 rtp://239.186.64.77:10000
 #EXTREM:spanish
-#EXTINF:-1 tvg-id="Aragontv.es" tvg-name="aragon TV ES" tvg-logo="https://static.epg.best/es/aragontv.es.png" tvg-chno="" channel-id="",Aragon int
+#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="aragon TV ES" tvg-logo="https://static.epg.best/es/aragontv.es.png" tvg-chno="" channel-id="",Aragon int
 rtp://239.186.66.62:10000
-#EXTINF:-1 tvg-id="24Horas.es" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
 rtp://239.186.64.196:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="TVGalicia.es" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
 rtp://239.186.64.187:10000
-#EXTINF:-1 tvg-id="tve.es" tvg-name="tve ES" tvg-logo="https://static.epg.best/es/tve.es.png" tvg-chno="469" channel-id="469",tve international
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="tve ES" tvg-logo="https://static.epg.best/es/tve.es.png" tvg-chno="469" channel-id="469",tve international
 rtp://239.186.64.54:10000
 #EXTREM:turkish
-#EXTINF:-1 tvg-id=""360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk
+#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk
 rtp://239.186.64.204:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv turk
+#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv turk
 rtp://239.186.64.201:10000
-#EXTINF:-1 tvg-id="Showmax.tr" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
-#EXTINF:-1 tvg-id="ShowTV.tr" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
 rtp://239.186.64.200:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
-#EXTINF:-1 tvg-id="TV8.tr" tvg-name="TV8 TR" tvg-logo="https://static.epg.best/tr/TV8.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 TR" tvg-logo="https://static.epg.best/tr/TV8.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
 rtp://239.186.64.205:10000
-#EXTINF:-1 tvg-id="Eurostar.tr" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="EuroD.tr" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",EURO D
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",EURO D
 rtp://239.186.64.199:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="602" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
 rtp://239.186.66.204:10000
-#EXTINF:-1 tvg-id="CNNTurk.tr" tvg-name="CNN Turk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
+#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNN Turk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
 rtp://239.186.74.75:10000
 #EXTREM:others foreign language not listed above
-#EXTINF:-1 tvg-id="2MMonde.ma" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="Alarabiya.sa" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
 rtp://239.186.64.192:10000
-#EXTINF:-1 tvg-id="BVN.nl" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
 rtp://239.186.64.195:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI TV
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI TV
 rtp://239.186.66.119:10000
-#EXTINF:-1 tvg-id="DunaTV.hu" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
 rtp://239.186.74.52:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
 rtp://239.186.66.85:10000
-#EXTINF:-1 tvg-id="AlMasriya.eg" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasriya.eg.png" tvg-chno="443" channel-id="443",Al Masriya
+#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasriya.eg.png" tvg-chno="443" channel-id="443",Al Masriya
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
-#EXTINF:-1 tvg-id="Htv1.hr" tvg-name="HTV 1 HR" tvg-logo="https://static.epg.best/hr/Htv1.hr.png" tvg-chno="446" channel-id="446",HRT1
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="HTV 1 HR" tvg-logo="https://static.epg.best/hr/Htv1.hr.png" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="https://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN tv
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN tv
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
 rtp://239.186.66.132:10000
 #EXTINF:-1 tvg-id="PlanetaRTR.ru" tvg-name="Planeta RTR " tvg-logo="https://static.epg.best/tr/PlanetaRTR.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
-#EXTINF:-1 tvg-id="ProTV.ro" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="https://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK.al" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
-#EXTINF:-1 tvg-id="TVRi.ro" tvg-name="TVRi RO" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="371" tvg-name="TVRi RO" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
-#EXTINF:-1 tvg-id="AlJazeeraArabic.qa" tvg-name="AlJazeeraArabic QA" tvg-logo="https://static.epg.best/qa/AlJazeera.qa.png" tvg-chno="115" channel-id="115",Al Jazeera Arabic
+#EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-name="AlJazeeraArabic QA" tvg-logo="https://static.epg.best/qa/AlJazeera.qa.png" tvg-chno="115" channel-id="115",Al Jazeera Arabic
 rtp://239.186.64.173:10000
-#EXTINF:-1 ,TV Duga+ (bos)
+#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD" ,TV Duga+ (bos)
 rtp://239.186.74.77:10000
-#EXTINF:-1 ,HRT int. (hrv)
+#EXTINF:-1 tvg-id="HRTInternational.hr@SD" ,HRT int. (hrv)
 rtp://239.186.74.83:10000
-#EXTINF:-1 ,Tunisie Nationale (ara)
+#EXTINF:-1 tvg-id="ElWatania1.tn@SD" ,Tunisie Nationale (ara)
 rtp://239.186.74.89:10000
-#EXTINF:-1 ,YKPAÏHA 24  / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="1919" ,YKPAÏHA 24  / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 ,Espreso TV (ukr)
 rtp://239.186.74.158:10000
-#EXTINF:-1 ,1+1 int. (ukr)
+#EXTINF:-1 tvg-id="2081" ,1+1 int. (ukr)
 rtp://239.186.74.9:10000
-#EXTINF:-1 ,RTVI (rus)
+#EXTINF:-1 tvg-id="371" ,RTVI (rus)
 rtp://239.186.74.2:10000

--- a/swisscom-sd.m3u
+++ b/swisscom-sd.m3u
@@ -3,245 +3,245 @@
 #EXTEPG url-tvg=""
 #PLAYLIST: bluetv channel free open standard size 576i, codec video h.264 only on host Swisscom network or partners of multicast network
 #EXTREM:french
-#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="Blue Zoom F CH" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="0" channel-id="0",blue zoom F
+#EXTINF:-1 tvg-id="BlueZoomF.ch@SD" tvg-name="blue Zoom F" tvg-logo="https://static.epg.best/ch/BlueZoomF.ch.png" tvg-chno="0" channel-id="0",blue zoom F
 rtp://239.186.64.111:10000
-#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS1" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS1
+#EXTINF:-1 tvg-id="RTS1.ch@SD" tvg-name="RTS 1" tvg-logo="https://static.epg.best/ch/RTS1.ch.png" tvg-chno="91" channel-id="91",RTS1
 rtp://239.186.64.5:10000
-#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS2" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS2
+#EXTINF:-1 tvg-id="RTS2.ch@SD" tvg-name="RTS 2" tvg-logo="https://static.epg.best/ch/RTS2.ch.png" tvg-chno="93" channel-id="93",RTS2
 rtp://239.186.64.6:10000
 #EXTINF:-1 tvg-id="TF1Switzerland.ch@SD" tvg-name="TF1" tvg-logo="https://static.epg.best/fr/TF1.fr.png" tvg-chno="99" channel-id="99",TF1 CH
 rtp://239.186.64.35:10000
-#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2 FR" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
+#EXTINF:-1 tvg-id="France2.fr@SD" tvg-name="France 2" tvg-logo="https://static.epg.best/fr/France2.fr.png" tvg-chno="54" channel-id="54",France2
 rtp://239.186.64.36:10000
-#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3 FR" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
+#EXTINF:-1 tvg-id="France3.fr@SD" tvg-name="France 3" tvg-logo="https://static.epg.best/fr/France3.fr.png" tvg-chno="56" channel-id="56",France3
 rtp://239.186.64.37:10000
-#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4 FR" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 / culturebox
+#EXTINF:-1 tvg-id="France4.fr@SD" tvg-name="France 4" tvg-logo="https://static.epg.best/fr/France4.fr.png" tvg-chno="58" channel-id="58",France4 / culturebox
 rtp://239.186.64.38:10000
-#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5 FR" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
+#EXTINF:-1 tvg-id="France5.fr@SD" tvg-name="France 5" tvg-logo="https://static.epg.best/fr/France5.fr.png" tvg-chno="59" channel-id="59",France5
 rtp://239.186.64.39:10000
-#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6 FR" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
+#EXTINF:-1 tvg-id="M6.ch@SD" tvg-name="M6" tvg-logo="https://static.epg.best/fr/M6.fr.png" tvg-chno="79" channel-id="79",M6 CH
 rtp://239.186.64.40:10000
-#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC FR" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
+#EXTINF:-1 tvg-id="TMC.fr@SD" tvg-name="TMC" tvg-logo="https://static.epg.best/fr/TMC.fr.png" tvg-chno="103" channel-id="103",TMC CH
 rtp://239.186.64.127:10000
-#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX FR" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH
+#EXTINF:-1 tvg-id="TFXSwitzerland.ch@SD" tvg-name="TFX" tvg-logo="https://static.epg.best/fr/TFX.fr.png" tvg-chno="101" channel-id="101",TFX CH
 rtp://239.186.64.42:10000
-#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9 FR" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
+#EXTINF:-1 tvg-id="W9Switzerland.ch@SD" tvg-name="W9" tvg-logo="https://static.epg.best/fr/W9.fr.png" tvg-chno="113" channel-id="113",W9 CH
 rtp://239.186.66.24:10000
-#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte FR" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
+#EXTINF:-1 tvg-id="arte.fr@SD" tvg-name="Arte Français" tvg-logo="https://static.epg.best/fr/ARTE.fr.png" tvg-chno="32" channel-id="32",arte F
 rtp://239.186.64.57:10000
-#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3 FR" tvg-logo="https://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
+#EXTINF:-1 tvg-id="AB3.be@SD" tvg-name="AB 3" tvg-logo="https://static.epg.best/fr/AB3.fr.png" tvg-chno="30" channel-id="30",AB3 CH
 rtp://239.186.66.229:10000
-#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="8 Mont-Blanc FR" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
+#EXTINF:-1 tvg-id="TV8MontBlanc.fr@SD" tvg-name="TV8 Mont Blanc" tvg-logo="https://static.epg.best/fr/TV8MontBlanc.fr.png" tvg-chno="28" channel-id="28",8Mont-Blanc
 rtp://239.186.64.144:10000
-#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV FR" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
+#EXTINF:-1 tvg-id="BFMTV.fr@SD" tvg-name="BFM TV" tvg-logo="https://static.epg.best/fr/BFMTV.fr.png" tvg-chno="37" channel-id="37",BFMTV CH
 rtp://239.186.64.72:10000
-#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="carac4 CH" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="39" channel-id="39",carac4
+#EXTINF:-1 tvg-id="TVSuissePlus.ch@SD" tvg-name="CARAC 4" tvg-logo="https://static.epg.best/ch/carac4.ch.png" tvg-chno="39" channel-id="39",carac4
 rtp://239.186.66.239:10000
-#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal9 CH" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="42" channel-id="42",Canal9
+#EXTINF:-1 tvg-id="Canal9.ch@SD" tvg-name="Canal 9" tvg-logo="https://static.epg.best/ch/Canal9.ch.png" tvg-chno="42" channel-id="42",Canal9
 rtp://239.186.64.108:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="44" channel-id="44",Canal Alpha JU
 rtp://239.186.64.106:10000
-#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha CH" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
+#EXTINF:-1 tvg-id="CanalAlphaJU.ch@SD" tvg-name="Canal Alpha JU" tvg-logo="https://static.epg.best/ch/CanalAlpha.ch.png" tvg-chno="46" channel-id="46",Canal Alpha NE
 rtp://239.186.64.92:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews FR" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/fr/Euronews.fr.png" tvg-chno="52" channel-id="52",euronews. F
 rtp://239.186.64.151:10000
-#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="France Info FR" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
+#EXTINF:-1 tvg-id="Franceinfo.fr@SD" tvg-name="franceinfo" tvg-logo="https://static.epg.best/fr/FranceInfo.fr.png" tvg-chno="62" channel-id="62",franceinfo
 rtp://239.186.66.225:10000
-#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24 FR" tvg-logo="https://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
+#EXTINF:-1 tvg-id="France24.fr@French" tvg-name="France 24" tvg-logo="https://static.epg.best/fr/France24.fr.png" tvg-chno="63" channel-id="63",France24
 rtp://239.186.64.41:10000
-#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli FR" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
+#EXTINF:-1 tvg-id="Gulli.fr@SD" tvg-name="Gulli" tvg-logo="https://static.epg.best/fr/Gulli.fr.png" tvg-chno="64" channel-id="64",gulli
 rtp://239.186.66.23:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="I24News FR" tvg-logo="https://static.epg.best/fr/i24news.fr.png" tvg-chno="66" channel-id="66",i24 NEWS F
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="https://static.epg.best/fr/i24news.fr.png" tvg-chno="66" channel-id="66",i24 NEWS F
 rtp://239.186.66.174:10000
-#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNews FR" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
+#EXTINF:-1 tvg-id="CNews.fr@SD" tvg-name="CNEWS" tvg-logo="https://static.epg.best/fr/CNews.fr.png" tvg-chno="68" channel-id="68",CNEWS
 rtp://239.186.66.25:10000
-#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO FR" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
+#EXTINF:-1 tvg-id="KTO.fr@SD" tvg-name="KTO" tvg-logo="https://static.epg.best/fr/KTO.fr.png" tvg-chno="70" channel-id="70",KtO
 rtp://239.186.64.148:10000
-#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="LA TELE CH" tvg-logo="https://static.epg.best/ch/LaTele.ch.png" tvg-chno="72" channel-id="72",LA TELE
+#EXTINF:-1 tvg-id="LaTele.ch@SD" tvg-name="La Télé" tvg-logo="https://static.epg.best/ch/LaTele.ch.png" tvg-chno="72" channel-id="72",LA TELE
 rtp://239.186.64.104:10000
-#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="LCI FR" tvg-logo="https://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD" tvg-name="Top Calcio 24" tvg-logo="https://static.epg.best/fr/LCI.fr.png" tvg-chno="74" channel-id="74",LCI La Chaine Info
 rtp://239.186.66.94:10000
-#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Leman Bleu CH" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="75" channel-id="75",lemanbleu
+#EXTINF:-1 tvg-id="LemanBleu.ch@SD" tvg-name="Léman Bleu Télévision" tvg-logo="https://static.epg.best/ch/LemanBleu.ch.png" tvg-chno="75" channel-id="75",lemanbleu
 rtp://239.186.64.89:10000
-#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="81" channel-id="81",maxtv/DieuTV
+#EXTINF:-1 tvg-id="MaxTV.ch@SD" tvg-name="Max TV" tvg-logo="" tvg-chno="81" channel-id="81",maxtv/DieuTV
 rtp://239.186.64.102:10000
-#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
+#EXTINF:-1 tvg-id="NRTV.ch@SD" tvg-name="NRTV" tvg-logo="" tvg-chno="85" channel-id="85",nrtv
 rtp://239.186.66.198:10000
-#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="TeleBielingue CH" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="302" channel-id="302",TeleBielingue
+#EXTINF:-1 tvg-id="TeleBielingue.ch@SD" tvg-name="Tele Bielingue" tvg-logo="https://static.epg.best/ch/TeleBielingue.ch.png" tvg-chno="302" channel-id="302",TeleBielingue
 rtp://239.186.64.95:10000
-#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="carac1 CH" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="88" channel-id="88",carac1
+#EXTINF:-1 tvg-id="RougeTV.ch@SD" tvg-name="CARAC 1" tvg-logo="https://static.epg.best/ch/carac1.ch.png" tvg-chno="88" channel-id="88",carac1
 rtp://239.186.64.145:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="95" channel-id="95",GRTV Genève Region TV
 rtp://239.186.64.69:10000
-#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV 5 Monde Europe FR" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="107" channel-id="107",TV5MONDE EUROPE
+#EXTINF:-1 tvg-id="TV5MondeEurope.fr@SD" tvg-name="TV5 MONDE EUROPE" tvg-logo="https://static.epg.best/fr/TV5MondeEurope.fr.png" tvg-chno="107" channel-id="107",TV5MONDE EUROPE
 rtp://239.186.64.71:10000
-#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV 5 Monde F-Be-Ch FR" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
+#EXTINF:-1 tvg-id="TV5MondeFranceBelgiumSwitzerlandMonaco.fr@SD" tvg-name="TV5 Monde FBS" tvg-logo="https://static.epg.best/fr/TV5Monde.fr.png" tvg-chno="108" channel-id="108",TV5 MONDE FRANCE BELGIQUE SUISSE MONACO
 rtp://239.186.64.150:10000
-#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3 CH" tvg-logo="https://static.epg.best/ch/TVM3.ch.png" tvg-chno="110" channel-id="110",tvm3
+#EXTINF:-1 tvg-id="TVM3.ch@SD" tvg-name="TVM3" tvg-logo="https://static.epg.best/ch/TVM3.ch.png" tvg-chno="110" channel-id="110",tvm3
 rtp://239.186.64.98:10000
-#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter FR" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="111" channel-id="111",6ter
+#EXTINF:-1 tvg-id="6terSwitzerland.ch@SD" tvg-name="6ter" tvg-logo="https://static.epg.best/fr/6ter.fr.png" tvg-chno="111" channel-id="111",6ter
 rtp://239.186.66.130:10000
-#EXTINF:-1 tvg-id="ORTBTV.bj@SD" tvg-name="ortb BJ" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
+#EXTINF:-1 tvg-id="ORTBTV.bj@SD" tvg-name="ORTB" tvg-logo="https://static.epg.best/bj/ORTB.bj.png" tvg-chno="111" channel-id="111",ortb
 rtp://239.186.74.97:10000
 #EXTREM:english
-#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC1 UK" tvg-logo="https://static.epg.best/gb/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC ONE
+#EXTINF:-1 tvg-id="BBCOne.uk@London" tvg-name="BBC One" tvg-logo="https://static.epg.best/gb/BBC1.uk.png" tvg-chno="118" channel-id="118",BBC ONE
 rtp://239.186.64.51:10000
-#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC2 UK" tvg-logo="https://static.epg.best/gb/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC TWO
+#EXTINF:-1 tvg-id="BBCTwo.uk@England" tvg-name="BBC Two" tvg-logo="https://static.epg.best/gb/BBC2.uk.png" tvg-chno="120" channel-id="120",BBC TWO
 rtp://239.186.64.165:10000
-#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="CBBC UK" tvg-logo="https://static.epg.best/gb/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC / BBC THREE
+#EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="https://static.epg.best/gb/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC / BBC THREE
 rtp://239.186.64.166:10000
-#EXTINF:-1 tvg-id="38" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
+#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
 rtp://239.186.64.52:10000
-#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies UK" tvg-logo="https://static.epg.best/gb/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
+#EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="https://static.epg.best/gb/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
-#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC NEWS UK" tvg-logo="https://static.epg.best/gb/BBCNews.uk.png" tvg-chno="129" channel-id="129",BBC NEWS (UK)
+#EXTINF:-1 tvg-id="BBCNews.uk@Africa" tvg-name="BBC News" tvg-logo="https://static.epg.best/gb/BBCNews.uk.png" tvg-chno="129" channel-id="129",BBC NEWS (UK)
 rtp://239.186.64.176:10000
-#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV UK" tvg-logo="https://static.epg.best/gb/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
+#EXTINF:-1 tvg-id="BloombergTV.us@Europe" tvg-name="Bloomberg TV" tvg-logo="https://static.epg.best/gb/BloombergTV.uk.png" tvg-chno="131" channel-id="131",Bloomberg TV
 rtp://239.186.64.177:10000
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN AU" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-name="CGTN" tvg-logo="https://static.epg.best/au/CGTN.au.png" tvg-chno="135" channel-id="135",CGTN
 rtp://239.186.66.114:10000
-#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4 UK" tvg-logo="https://static.epg.best/gb/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
+#EXTINF:-1 tvg-id="Channel4.uk@UK" tvg-name="Channel 4" tvg-logo="https://static.epg.best/gb/Channel4.uk.png" tvg-chno="137" channel-id="137",Channel4
 rtp://239.186.64.183:10000
-#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s UK" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",NOW 70s
+#EXTINF:-1 tvg-id="Now70s.uk@SD" tvg-name="Now 70s" tvg-logo="https://static.epg.best/gb/Now70s.uk.png" tvg-chno="" channel-id="",NOW 70s
 rtp://239.186.74.108:10000
-#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s UK" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",NOW 80s
+#EXTINF:-1 tvg-id="Now80s.uk@SD" tvg-name="Now 80s" tvg-logo="https://static.epg.best/gb/Now80s.uk.png" tvg-chno="" channel-id="",NOW 80s
 rtp://239.186.74.106:10000
-#EXTINF:-1 tvg-id="NOWRock.uk@SD" tvg-name="Now Rock UK" tvg-logo="https://static.epg.best/gb/Nowrock.uk.png" tvg-chno="140" channel-id="140",NOW Rock
+#EXTINF:-1 tvg-id="NOWRock.uk@SD" tvg-name="Now Rock" tvg-logo="https://static.epg.best/gb/Nowrock.uk.png" tvg-chno="140" channel-id="140",NOW Rock
 rtp://239.186.66.133:10000
-#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV UK" tvg-logo="https://static.epg.best/gb/ClublandTV.uk.png" tvg-chno="141" channel-id="141",Clubland
+#EXTINF:-1 tvg-id="ClublandTV.uk@SD" tvg-name="Clubland TV" tvg-logo="https://static.epg.best/gb/ClublandTV.uk.png" tvg-chno="141" channel-id="141",Clubland
 rtp://239.186.66.116:10000
 #EXTINF:-1 tvg-id="CNBCEurope.uk@SD" tvg-name="CNBC UK" tvg-logo="https://static.epg.best/gb/CNBC.uk.png" tvg-chno="142" channel-id="142",CNBC EU
 rtp://239.186.64.167:10000
-#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN UK" tvg-logo="https://static.epg.best/gb/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
+#EXTINF:-1 tvg-id="CNNInternational.us@MENA" tvg-name="CNN" tvg-logo="https://static.epg.best/gb/CNN.uk.png" tvg-chno="144" channel-id="144",CNN International
 rtp://239.186.64.175:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="207" channel-id="207",DEUTSCHE WELLE En
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="902" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
+#EXTINF:-1 tvg-id="" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
 rtp://239.186.66.140:10000
-#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4 UK" tvg-logo="https://static.epg.best/gb/E4.uk.png" tvg-chno="147" channel-id="147",E4
+#EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4" tvg-logo="https://static.epg.best/gb/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="EuroNews UK" tvg-logo="https://static.epg.best/gb/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews E
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/gb/EuroNews.uk.png" tvg-chno="148" channel-id="148",euronews E
 rtp://239.186.64.178:10000
-#EXTINF:-1 tvg-id="1781" tvg-name="Fashion TV FR" tvg-logo="https://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
+#EXTINF:-1 tvg-id="FashionTVEurope.fr@SD" tvg-name="Fashion TV" tvg-logo="https://static.epg.best/fr/FashionTV.fr.png" tvg-chno="150" channel-id="150",Fashion TV
 rtp://239.186.64.174:10000
 #EXTINF:-1 tvg-id="Film4.uk" tvg-name="Film4 UK" tvg-logo="https://static.epg.best/uk/Film4.uk.png" tvg-chno="152" channel-id="152",Film4
 rtp://239.186.64.172:10000
-#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5 UK" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="153" channel-id="153",Channel5
+#EXTINF:-1 tvg-id="Channel5.uk@SD" tvg-name="Channel 5" tvg-logo="https://static.epg.best/gb/Channel5.uk.png" tvg-chno="153" channel-id="153",Channel5
 rtp://239.186.64.184:10000
-#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network UK" tvg-logo="https://static.epg.best/gb/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
+#EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/gb/FoodNetwork.uk.png" tvg-chno="155" channel-id="155",food network E
 rtp://239.186.66.58:10000
-#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24news IL" tvg-logo="https://static.epg.best/il/i24news.png" tvg-chno="157" channel-id="157",i24 NEWS E
+#EXTINF:-1 tvg-id="i24NEWSEnglishWorld.il@SD" tvg-name="i24 News" tvg-logo="https://static.epg.best/il/i24news.png" tvg-chno="157" channel-id="157",i24 NEWS E
 rtp://239.186.66.126:10000
-#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV UK" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="159" channel-id="159",itv1
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="https://static.epg.best/gb/ITV1.uk.png" tvg-chno="159" channel-id="159",itv1
 rtp://239.186.64.169:10000
-#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2 UK" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
+#EXTINF:-1 tvg-id="ITV2.uk@SD" tvg-name="ITV2" tvg-logo="https://static.epg.best/gb/ITV2.uk.png" tvg-chno="161" channel-id="161",itv2
 rtp://239.186.64.170:10000
-#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3 UK" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
+#EXTINF:-1 tvg-id="ITV3.uk@SD" tvg-name="ITV3" tvg-logo="https://static.epg.best/gb/ITV3.uk.png" tvg-chno="162" channel-id="162",itv3
 rtp://239.186.64.180:10000
-#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4 UK" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
+#EXTINF:-1 tvg-id="ITV4.uk@SD" tvg-name="ITV4" tvg-logo="https://static.epg.best/gb/ITV4.uk.png" tvg-chno="163" channel-id="163",itv4
 rtp://239.186.64.171:10000
-#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More4 UK" tvg-logo="https://static.epg.best/gb/More4.uk.png" tvg-chno="167" channel-id="167",More4
+#EXTINF:-1 tvg-id="More4.uk@SD" tvg-name="More 4" tvg-logo="https://static.epg.best/gb/More4.uk.png" tvg-chno="167" channel-id="167",More4
 rtp://239.186.64.185:10000
-#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News UK" tvg-logo="https://static.epg.best/gb/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news international
+#EXTINF:-1 tvg-id="SkyNewsInternational.uk@SD" tvg-name="Sky News International" tvg-logo="https://static.epg.best/gb/SkyNews.uk.png" tvg-chno="170" channel-id="170",sky news international
 rtp://239.186.64.179:10000
-#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA UK" tvg-logo="https://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA UK
+#EXTINF:-1 tvg-id="5USA.uk@SD" tvg-name="5USA" tvg-logo="https://static.epg.best/gb/FiveUSA.uk.png" tvg-chno="" channel-id="",5USA UK
 rtp://239.186.66.242:10000
-#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBCParliament uk" tvg-logo="https://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC PARLIAMENT
+#EXTINF:-1 tvg-id="BBCParliament.uk@SD" tvg-name="BBC Parliament" tvg-logo="https://static.epg.best/gb/BBCParliament.uk.png" tvg-chno="" channel-id="",BBC PARLIAMENT
 rtp://239.186.74.25:10000
-#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America UK" tvg-logo="https://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America UK
+#EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America" tvg-logo="https://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America UK
 rtp://239.186.66.243:10000
-#EXTINF:-1 tvg-id="1507" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
+#EXTINF:-1 tvg-id="" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
 rtp://239.186.66.253:10000
-#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star UK" tvg-logo="https://static.epg.best/gb/5star.uk.png" tvg-chno="" channel-id="",5STAR
+#EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star" tvg-logo="https://static.epg.best/gb/5star.uk.png" tvg-chno="" channel-id="",5STAR
 rtp://239.186.74.72:10000
-#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5Select UK" tvg-logo="https://static.epg.best/gb/5select.uk.png" tvg-chno="" channel-id="",5SELECT
+#EXTINF:-1 tvg-id="5SELECT.uk@SD" tvg-name="5SELECT" tvg-logo="https://static.epg.best/gb/5select.uk.png" tvg-chno="" channel-id="",5SELECT
 rtp://239.186.74.88:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DiscoveryDMAX UK" tvg-logo="https://static.epg.best/gb/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="https://static.epg.best/gb/DiscoveryDMAX.uk.png" tvg-chno="" channel-id="",DMAX UK
 rtp://239.186.74.74:10000
-#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5ACTION UK" tvg-logo="https://static.epg.best/gb/5ACTION.uk.png" tvg-chno="" channel-id="",5ACTION
+#EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5Action" tvg-logo="https://static.epg.best/gb/5ACTION.uk.png" tvg-chno="" channel-id="",5ACTION
 rtp://239.186.74.84:10000
-#EXTINF:-1 tvg-id="1674" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
-#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven UK" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
+#EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="2017" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
+#EXTINF:-1 tvg-id="" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
 rtp://239.186.74.94:10000
-#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge UK" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
+#EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
 #EXTINF:-1 tvg-id="TrueCrime.uk" tvg-name="True Crime UK" tvg-logo="https://static.epg.best/gb/truecrime.uk.png" tvg-chno="" channel-id="",TRUE CRIME UK
 rtp://239.186.74.107:10000
-#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance UK" tvg-logo="https://static.epg.best/gb/GreatRomance.uk.png" tvg-chno="" channel-id="",GREAT! romance
+#EXTINF:-1 tvg-id="GREATromance.uk@UK" tvg-name="Great! Romance" tvg-logo="https://static.epg.best/gb/GreatRomance.uk.png" tvg-chno="" channel-id="",GREAT! romance
 rtp://239.186.74.53:10000
-#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Great! Action UK" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
+#EXTINF:-1 tvg-id="Action.fr@SD" tvg-name="Action" tvg-logo="https://static.epg.best/gb/GreatAction.uk.png" tvg-chno="" channel-id="",GREAT! action
 rtp://239.186.74.58:10000
 #EXTINF:-1 tvg-id="GreatMystery.uk" tvg-name="Great! Mystery UK" tvg-logo="https://static.epg.best/gb/GreatMystery.uk.png" tvg-chno="" channel-id="",GREAT! Mystery
 rtp://239.186.74.11:10000
 #EXTREM:german
-#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SF 1 CH" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
+#EXTINF:-1 tvg-id="SRF1.ch@SD" tvg-name="SRF 1" tvg-logo="https://static.epg.best/ch/SRF1.ch.png" tvg-chno="281" channel-id="281",SRF1
 rtp://239.186.64.2:10000
-#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SF zwei CH" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
+#EXTINF:-1 tvg-id="SRFzwei.ch@SD" tvg-name="SRF zwei" tvg-logo="https://static.epg.best/ch/SRF2.ch.png" tvg-chno="283" channel-id="283",SRF2 SRF zwei
 rtp://239.186.64.3:10000
-#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SF Info CH" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
+#EXTINF:-1 tvg-id="SRFinfo.ch@SD" tvg-name="SRF info" tvg-logo="https://static.epg.best/ch/SRFInfo.ch.png" tvg-chno="285" channel-id="285",SRF info
 rtp://239.186.64.4:10000
 #EXTINF:-1 tvg-id="3sat.de@SD" tvg-name="3sat" tvg-logo="https://static.epg.best/at/3sat.at.png" tvg-chno="174" channel-id="174",3sat
 rtp://239.186.64.55:10000
-#EXTINF:-1 tvg-id="1908" tvg-name="3+ CH" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
+#EXTINF:-1 tvg-id="3Plus.ch@SD" tvg-name="3+" tvg-logo="https://static.epg.best/ch/3Plus.ch.png" tvg-chno="172" channel-id="172",3+
 rtp://239.186.64.56:10000
-#EXTINF:-1 tvg-id="1909" tvg-name="4+ CH" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
+#EXTINF:-1 tvg-id="4Plus.ch@SD" tvg-name="4+" tvg-logo="https://static.epg.best/ch/4Plus.ch.png" tvg-chno="176" channel-id="176",4+
 rtp://239.186.64.142:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="179" channel-id="179",AW1 TV
 rtp://239.186.64.112:10000
-#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste DE" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="182" channel-id="182",ARD Das Erste
+#EXTINF:-1 tvg-id="DasErste.de@SD" tvg-name="Das Erste" tvg-logo="https://static.epg.best/de/ARD.de.png" tvg-chno="182" channel-id="182",ARD Das Erste
 rtp://239.186.64.11:10000
-#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD Alpha DE" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha
+#EXTINF:-1 tvg-id="ARDalpha.de@SD" tvg-name="ARD-alpha" tvg-logo="https://static.epg.best/de/ARDalpha.de.png" tvg-chno="184" channel-id="184",ARD alpha
 rtp://239.186.64.119:10000
-#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One DE" tvg-logo="https://static.epg.best/de/One.de.png" tvg-chno="185" channel-id="185",ARD one
+#EXTINF:-1 tvg-id="One.de@SD" tvg-name="One" tvg-logo="https://static.epg.best/de/One.de.png" tvg-chno="185" channel-id="185",ARD one
 rtp://239.186.64.121:10000
-#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte DE" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="187" channel-id="187",arte D
+#EXTINF:-1 tvg-id="arte.de@SD" tvg-name="Arte Deutsch" tvg-logo="https://static.epg.best/de/ARTE.de.png" tvg-chno="187" channel-id="187",arte D
 rtp://239.186.64.23:10000
-#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV DE" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
+#EXTINF:-1 tvg-id="BibelTV.de@SD" tvg-name="Bibel TV" tvg-logo="https://static.epg.best/de/BibelTV.de.png" tvg-chno="191" channel-id="191",bibel.TV
 rtp://239.186.64.131:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="BR DE" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="https://static.epg.best/de/BR.de.png" tvg-chno="194" channel-id="194",BR
 rtp://239.186.64.26:10000
-#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="Helvetia One CH" tvg-logo="https://static.epg.best/ch/Helvetiaone.ch.png" tvg-chno="198" channel-id="198",HELVETIA ONE
+#EXTINF:-1 tvg-id="HelvetiaOneTV.ch@SD" tvg-name="Helvetia One TV" tvg-logo="https://static.epg.best/ch/Helvetiaone.ch.png" tvg-chno="198" channel-id="198",HELVETIA ONE
 rtp://239.186.66.238:10000
-#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen DE" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
+#EXTINF:-1 tvg-id="DMF.de@SD" tvg-name="Deutsches Musik Fernsehen" tvg-logo="https://static.epg.best/de/DeutschesMusikFernsehen.de.png" tvg-chno="202" channel-id="202",DMF
 rtp://239.186.66.118:10000
-#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel DE" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
+#EXTINF:-1 tvg-id="DisneyChannel.de@SD" tvg-name="Disney Channel D" tvg-logo="https://static.epg.best/de/DisneyChannel.de.png" tvg-chno="203" channel-id="203",Disney Channel
 rtp://239.186.64.116:10000
-#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RiC DE" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",RiC
+#EXTINF:-1 tvg-id="RiC.de@SD" tvg-name="RIC TV" tvg-logo="https://static.epg.best/de/RiC.de.png" tvg-chno="206" channel-id="206",RiC
 rtp://239.186.64.129:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews DE" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/de/Euronews.de.png" tvg-chno="208" channel-id="208",euronews. D
 rtp://239.186.64.137:10000
-#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope Channel Int. DE" tvg-logo="https://static.epg.best/de/HopeChannelInt.de.png" tvg-chno="214" channel-id="214",HopeTV
+#EXTINF:-1 tvg-id="HopeChannelGerman.de@SD" tvg-name="Hope TV" tvg-logo="https://static.epg.best/de/HopeChannelInt.de.png" tvg-chno="214" channel-id="214",HopeTV
 rtp://239.186.64.115:10000
-#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR DE" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
+#EXTINF:-1 tvg-id="hrfernsehen.de@SD" tvg-name="HR" tvg-logo="https://static.epg.best/de/HR.de.png" tvg-chno="216" channel-id="216",hr
 rtp://239.186.64.28:10000
-#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE DE" tvg-logo="https://static.epg.best/de/HSE.de.png" tvg-chno="218" channel-id="218",HSE
+#EXTINF:-1 tvg-id="HSE.de@SD" tvg-name="HSE" tvg-logo="https://static.epg.best/de/HSE.de.png" tvg-chno="218" channel-id="218",HSE
 rtp://239.186.64.123:10000
 #EXTINF:-1 tvg-id="Kabel1.de" tvg-name="Kabel 1 DE" tvg-logo="https://static.epg.best/de/Kabel1.de.png" tvg-chno="220" channel-id="220",kabel eins
 rtp://239.186.64.20:10000
-#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9 CH" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
+#EXTINF:-1 tvg-id="Kanal9.ch@SD" tvg-name="Kanal 9" tvg-logo="https://static.epg.best/ch/Kanal9.ch.png" tvg-chno="223" channel-id="223",Kanal9
 rtp://239.186.64.109:10000
-#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKA DE" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
+#EXTINF:-1 tvg-id="KiKA.de@SD" tvg-name="KiKa" tvg-logo="https://static.epg.best/de/Kika.de.png" tvg-chno="225" channel-id="225",KiKA
 rtp://239.186.64.31:10000
-#EXTINF:-1 tvg-id="627" tvg-name="K-TV DE" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
+#EXTINF:-1 tvg-id="KTV.at@SD" tvg-name="K-TV" tvg-logo="https://static.epg.best/de/KTV.de.png" tvg-chno="227" channel-id="227",k-tv
 rtp://239.186.64.133:10000
-#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly CH" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY
+#EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY
 rtp://239.186.66.231:10000
-#EXTINF:-1 tvg-id="256" tvg-name="MDR DE" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
-#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="" tvg-logo="" tvg-chno="231" channel-id="231",Melodie.tv
+#EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
-#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku DE" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
+#EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="286" tvg-name="NDR DE" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
-#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ CH" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="238" channel-id="238",7+
+#EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ / Nickelodeon" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="238" channel-id="238",7+
 rtp://239.186.64.186:10000
-#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="RTL Nitro DE" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
+#EXTINF:-1 tvg-id="Nitro.de@SD" tvg-name="Nitro" tvg-logo="https://static.epg.best/de/RTLNitro.de.png" tvg-chno="240" channel-id="240",NITRO.
 rtp://239.186.64.140:10000
-#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv DE" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
+#EXTINF:-1 tvg-id="ntv.de@SD" tvg-name="n-tv" tvg-logo="https://static.epg.best/de/ntv.de.png" tvg-chno="241" channel-id="241",ntv
 rtp://239.186.64.29:10000
 #EXTINF:-1 tvg-id="ORF1.at@SD" tvg-name="ORF 1" tvg-logo="https://static.epg.best/at/ORF1.at.png" tvg-chno="244" channel-id="244",ORF1
 rtp://239.186.64.13:10000
@@ -249,312 +249,312 @@ rtp://239.186.64.13:10000
 rtp://239.186.64.14:10000
 #EXTINF:-1 tvg-id="ORFIII.at@SD" tvg-name="ORF 3" tvg-logo="https://static.epg.best/at/ORF3.at.png" tvg-chno="248" channel-id="248",ORF3
 rtp://239.186.64.86:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix DE" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="https://static.epg.best/de/Phoenix.de.png" tvg-chno="249" channel-id="249",phoenix
 rtp://239.186.64.65:10000
-#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro 7 DE" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben
 rtp://239.186.64.19:10000
-#EXTINF:-1 tvg-id="342" tvg-name="RBB DE" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
+#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
 rtp://239.186.64.126:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL DE" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
+#EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="1770" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
+#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
 rtp://239.186.64.16:10000
-#EXTINF:-1 tvg-id="RTLup.de@SD" tvg-name="RTL Up DE" tvg-logo="https://static.epg.best/de/RTLUp.de.png" tvg-chno="262" channel-id="262",RTLup
+#EXTINF:-1 tvg-id="RTLup.de@SD" tvg-name="RTLup" tvg-logo="https://static.epg.best/de/RTLUp.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
-#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="Sat 1 DE" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
+#EXTINF:-1 tvg-id="SAT1.de@SD" tvg-name="SAT.1" tvg-logo="https://static.epg.best/de/Sat1.de.png" tvg-chno="264" channel-id="264",SAT.1 CH
 rtp://239.186.64.18:10000
 #EXTINF:-1 tvg-id="ServusTV.at@SD" tvg-name="Servus TV" tvg-logo="https://static.epg.best/at/ServusTV.at.png" tvg-chno="269" channel-id="269",ServusTV
 rtp://239.186.64.136:10000
-#EXTINF:-1 tvg-id="1325" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
+#EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="271" channel-id="271",SessionNationalrat
 rtp://239.186.66.146:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="273" channel-id="273",SessionStaenderat
 rtp://239.186.64.124:10000
-#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="" tvg-logo="" tvg-chno="276" channel-id="276",SHf
+#EXTINF:-1 tvg-id="SchaffhauserFernsehen.ch@SD" tvg-name="SHf - Schaffhauser Fernsehen" tvg-logo="" tvg-chno="276" channel-id="276",SHf
 rtp://239.186.64.97:10000
-#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="Sixx DE" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
+#EXTINF:-1 tvg-id="sixx.de@SD" tvg-name="sixx" tvg-logo="https://static.epg.best/de/sixx.de.png" tvg-chno="278" channel-id="278",SIXX CH
 rtp://239.186.64.70:10000
-#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport 1 DE" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",Sport1 CH
+#EXTINF:-1 tvg-id="Sport1.de@SD" tvg-name="Sport1" tvg-logo="https://static.epg.best/de/Sport1.de.png" tvg-chno="279" channel-id="279",Sport1 CH
 rtp://239.186.64.64:10000
-#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV CH" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
+#EXTINF:-1 tvg-id="StarTV.ch@SD" tvg-name="Star TV" tvg-logo="https://static.epg.best/ch/StarTV.ch.png" tvg-chno="287" channel-id="287",Star TV
 rtp://239.186.64.87:10000
-#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="RTL Super DE" tvg-logo="https://static.epg.best/de/RTLsuper.de.png" tvg-chno="290" channel-id="290",RTL SUPER
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super!" tvg-logo="https://static.epg.best/de/RTLsuper.de.png" tvg-chno="290" channel-id="290",RTL SUPER
 rtp://239.186.64.17:10000
-#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR DE" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >>
+#EXTINF:-1 tvg-id="SWRFernsehenBadenWurttemberg.de@SD" tvg-name="SWR" tvg-logo="https://static.epg.best/de/SWRSR.de.png" tvg-chno="293" channel-id="293",SWR >>
 rtp://239.186.64.27:10000
-#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau 24 DE" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24
+#EXTINF:-1 tvg-id="tagesschau24.de@SD" tvg-name="Tagesschau24" tvg-logo="https://static.epg.best/de/Tagesschau24.de.png" tvg-chno="295" channel-id="295",Tagesschau24
 rtp://239.186.64.120:10000
-#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele1 CH" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1
+#EXTINF:-1 tvg-id="Tele1.ch@SD" tvg-name="Tele 1" tvg-logo="https://static.epg.best/ch/Tele1.ch.png" tvg-chno="297" channel-id="297",Tele1
 rtp://239.186.64.91:10000
-#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Baern CH" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",tele baern
+#EXTINF:-1 tvg-id="TeleBarn.ch@SD" tvg-name="Tele Bärn" tvg-logo="https://static.epg.best/ch/TeleBaern.ch.png" tvg-chno="300" channel-id="300",tele baern
 rtp://239.186.64.60:10000
-#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1 CH" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
+#EXTINF:-1 tvg-id="TeleM1.ch@SD" tvg-name="Tele M1" tvg-logo="https://static.epg.best/ch/TeleM1.ch.png" tvg-chno="305" channel-id="305",Tele M1
 rtp://239.186.64.90:10000
-#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top CH" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
+#EXTINF:-1 tvg-id="TeleTop.ch@SD" tvg-name="Tele Top" tvg-logo="https://static.epg.best/ch/TeleTop.ch.png" tvg-chno="307" channel-id="307",Tele Top
 rtp://239.186.64.96:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="" tvg-chno="309" channel-id="309",TELEZ
 rtp://239.186.64.103:10000
-#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Zueri CH" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",Tele Zuri
+#EXTINF:-1 tvg-id="TeleZ.ch@SD" tvg-name="Tele Z" tvg-logo="https://static.epg.best/ch/TeleZueri.ch.png" tvg-chno="312" channel-id="312",Tele Zuri
 rtp://239.186.64.9:10000
-#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Tele Basel CH" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
+#EXTINF:-1 tvg-id="Telebasel.ch@SD" tvg-name="Telebasel" tvg-logo="https://static.epg.best/ch/TeleBasel.ch.png" tvg-chno="314" channel-id="314",Telebasel
 rtp://239.186.64.88:10000
-#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="Blue Zoom D CH" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="316" channel-id="316",blue zoom D
+#EXTINF:-1 tvg-id="BlueZoomD.ch@SD" tvg-name="blue Zoom D" tvg-logo="https://static.epg.best/ch/BlueZoomD.ch.png" tvg-chno="316" channel-id="316",blue zoom D
 rtp://239.186.66.129:10000
-#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo plus DE" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
+#EXTINF:-1 tvg-id="TOGGOplus.de@SD" tvg-name="Toggo Plus" tvg-logo="https://static.epg.best/de/TOGGOplus.de.png" tvg-chno="320" channel-id="320",TOGGO plus
 rtp://239.186.66.202:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="321" channel-id="321",TSO
 rtp://239.186.64.100:10000
-#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO CH" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
+#EXTINF:-1 tvg-id="TVO.ch@SD" tvg-name="TVO" tvg-logo="https://static.epg.best/ch/TVO.ch.png" tvg-chno="328" channel-id="328",tvo
 rtp://239.186.64.94:10000
-#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX DE" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
+#EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="654" tvg-name="WDR DE" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
-#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="Welt DE" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
+#EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
-#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF DE" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
+#EXTINF:-1 tvg-id="ZDF.de@SD" tvg-name="ZDF" tvg-logo="https://static.epg.best/de/ZDF.de.png" tvg-chno="339" channel-id="339",ZDF CH
 rtp://239.186.64.12:10000
-#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDF Info DE" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
+#EXTINF:-1 tvg-id="ZDFinfo.de@SD" tvg-name="ZDFinfo" tvg-logo="https://static.epg.best/de/ZDFinfo.de.png" tvg-chno="341" channel-id="341",zdf info
 rtp://239.186.64.118:10000
-#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDF Neo DE" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
+#EXTINF:-1 tvg-id="ZDFneo.de@SD" tvg-name="ZDFneo" tvg-logo="https://static.epg.best/de/ZDFneo.de.png" tvg-chno="343" channel-id="343",zdf_neo
 rtp://239.186.64.66:10000
-#EXTINF:-1 tvg-id="95" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="" channel-id="",HGTV DE
+#EXTINF:-1 tvg-id="" tvg-name="HGTV DE" tvg-logo="https://static.epg.best/de/HGTV.de.png" tvg-chno="" channel-id="",HGTV DE
 rtp://239.186.74.40:10000
-#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup DE" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="" channel-id="",VOXup
+#EXTINF:-1 tvg-id="Voxup.de@SD" tvg-name="VOXup" tvg-logo="https://static.epg.best/de/voxup.de.png" tvg-chno="" channel-id="",VOXup
 rtp://239.186.74.70:10000
-#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="schlager deluxe DE" tvg-logo="https://static.epg.best/de/schlagerdeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
+#EXTINF:-1 tvg-id="SchlagerDeluxe.de@SD" tvg-name="Schlager Deluxe" tvg-logo="https://static.epg.best/de/schlagerdeluxe.de.png" tvg-chno="" channel-id="",SCHLAGER DELUXE
 rtp://239.186.74.105:10000
-#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="volksmusik DE" tvg-logo="https://static.epg.best/de/volksmusik.de.png" tvg-chno="" channel-id="",volksmusik.tv
+#EXTINF:-1 tvg-id="VolksmusikTV.de@SD" tvg-name="Volksmusik.TV" tvg-logo="https://static.epg.best/de/volksmusik.de.png" tvg-chno="" channel-id="",volksmusik.tv
 rtp://239.186.74.113:10000
-#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="More Than Sports DE" tvg-logo="https://static.epg.best/de/morethansports.de.png" tvg-chno="205" channel-id="205",More Than Sports D
+#EXTINF:-1 tvg-id="MoreThanSportsTV.de@SD" tvg-name="More Than Sports TV" tvg-logo="https://static.epg.best/de/morethansports.de.png" tvg-chno="205" channel-id="205",More Than Sports D
 rtp://239.186.66.241:10000
-#EXTINF:-1 tvg-id="2055" ,stimmungsgarten.tv (deu)
+#EXTINF:-1 tvg-id=""  tvg-name="Stimmungsgarten TV",stimmungsgarten.tv (deu)
 rtp://239.186.74.148:10000
-#EXTINF:-1 tvg-id="2041" ,justcooking.tv (deu)
+#EXTINF:-1 tvg-id="" ,justcooking.tv (deu)
 rtp://239.186.74.150:10000
 #EXTINF:-1 ,just.fishing (deu)
 rtp://239.186.74.157:10000
 #EXTREM:italian
-#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI LA1 CH" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
+#EXTINF:-1 tvg-id="RSILa1.ch@SD" tvg-name="RSI La 1" tvg-logo="https://static.epg.best/ch/RSILA1.ch.png" tvg-chno="402" channel-id="402",RSI LA1
 rtp://239.186.64.7:10000
-#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA2 CH" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
+#EXTINF:-1 tvg-id="RSILa2.ch@SD" tvg-name="RSI LA 2" tvg-logo="https://static.epg.best/ch/RSILA2.ch.png" tvg-chno="404" channel-id="404",RSI LA2
 rtp://239.186.64.8:10000
 #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="" tvg-chno="346" channel-id="346",7G Telecity
 rtp://239.186.74.23:10000
-#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="	Almatv IT" tvg-logo="https://static.epg.best/it/Almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
+#EXTINF:-1 tvg-id="AlmaTV.it@SD" tvg-name="ALMA TV" tvg-logo="https://static.epg.best/it/Almatv.it.png" tvg-chno="347" channel-id="347",ALMA TV
 rtp://239.186.66.107:10000
-#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
+#EXTINF:-1 tvg-id="AntennaTre.it@SD" tvg-name="Antenna 3" tvg-logo="" tvg-chno="348" channel-id="348",ANTENNA3 A3
 rtp://239.186.74.18:10000
-#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing IT" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
+#EXTINF:-1 tvg-id="Boing.it@SD" tvg-name="Boing I" tvg-logo="https://static.epg.best/it/Boing.it.png" tvg-chno="349" channel-id="349",Boing I
 rtp://239.186.64.74:10000
-#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
+#EXTINF:-1 tvg-id="CanaleItalia.it@SD" tvg-name="Canale Italia" tvg-logo="" tvg-chno="350" channel-id="350",CANALE Italia
 rtp://239.186.64.160:10000
-#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito IT" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",Cartoonito
+#EXTINF:-1 tvg-id="Boing.fr@SD" tvg-name="Cartoonito F" tvg-logo="https://static.epg.best/it/Cartoonito.it.png" tvg-chno="351" channel-id="351",Cartoonito
 rtp://239.186.66.176:10000
-#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo IT" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
+#EXTINF:-1 tvg-id="Cielo.it@SD" tvg-name="Cielo" tvg-logo="https://static.epg.best/it/Cielo.it.png" tvg-chno="352" channel-id="352",cielo
 rtp://239.186.64.76:10000
-#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="" tvg-logo="" tvg-chno="354" channel-id="354",ClassTV Moda
+#EXTINF:-1 tvg-id="ClassTVModa.it@SD" tvg-name="Class TV Moda" tvg-logo="" tvg-chno="354" channel-id="354",ClassTV Moda
 rtp://239.186.66.189:10000
-#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX IT" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros Discovery DMAX
+#EXTINF:-1 tvg-id="DMAX.uk@UK" tvg-name="DMAX UK" tvg-logo="https://static.epg.best/it/DMAX.it.png" tvg-chno="355" channel-id="355",Warner Bros Discovery DMAX
 rtp://239.186.66.110:10000
-#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee IT" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros Discovery FRISBEE
+#EXTINF:-1 tvg-id="Frisbee.it@SD" tvg-name="Frisbee" tvg-logo="https://static.epg.best/it/Frisbee.it.png" tvg-chno="356" channel-id="356",Warner Bros Discovery FRISBEE
 rtp://239.186.66.188:10000
-#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo IT" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros Discovery Giallo
+#EXTINF:-1 tvg-id="Giallo.it@SD" tvg-name="Giallo" tvg-logo="https://static.epg.best/it/Giallo.it.png" tvg-chno="357" channel-id="357",Warner Bros Discovery Giallo
 rtp://239.186.66.187:10000
-#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2 IT" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros Discovery K2
+#EXTINF:-1 tvg-id="K2.it@SD" tvg-name="K2" tvg-logo="https://static.epg.best/it/K2.it.png" tvg-chno="358" channel-id="358",Warner Bros Discovery K2
 rtp://239.186.66.186:10000
-#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend IT" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
+#EXTINF:-1 tvg-id="MotorTrend.it@SD" tvg-name="Motor Trend" tvg-logo="https://static.epg.best/it/MotorTrend.it.png" tvg-chno="359" channel-id="359",Warner Bros Discovery MOTOR TREND
 rtp://239.186.74.21:10000
 #EXTINF:-1 tvg-id="FoodNetwork.it@SD" tvg-name="Food Network IT" tvg-logo="https://static.epg.best/it/FoodNetwork.it.png" tvg-chno="364" channel-id="364",Warner Bros Discovery food network I
 rtp://239.186.66.122:10000
-#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE IT" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Warner Bros Discovery NOVE
+#EXTINF:-1 tvg-id="Nove.it@SD" tvg-name="NOVE" tvg-logo="https://static.epg.best/it/NOVE.it.png" tvg-chno="360" channel-id="360",Warner Bros Discovery NOVE
 rtp://239.186.64.158:10000
-#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time IT" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros Discovery Real Time
+#EXTINF:-1 tvg-id="RealTime.it@SD" tvg-name="Real Time" tvg-logo="https://static.epg.best/it/RealTime.it.png" tvg-chno="362" channel-id="362",Warner Bros Discovery Real Time
 rtp://239.186.66.43:10000
-#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews IT" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
+#EXTINF:-1 tvg-id="EuronewsAlbania.al@SD" tvg-name="Euronews AL" tvg-logo="https://static.epg.best/it/Euronews.it.png" tvg-chno="363" channel-id="363",euronews. I
 rtp://239.186.64.153:10000
-#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL 123
+#EXTINF:-1 tvg-id="ItaliaChannel.it@SD" tvg-name="Italia Channel" tvg-logo="" tvg-chno="365" channel-id="365",ITALIA CHANNEL 123
 rtp://239.186.74.19:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7 IT" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="https://static.epg.best/it/La7.it.png" tvg-chno="366" channel-id="366",LA7
 rtp://239.186.64.49:10000
-#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La7cinema IT" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA
+#EXTINF:-1 tvg-id="LA7.it@SD" tvg-name="La 7" tvg-logo="https://static.epg.best/it/La7cinema.it.png" tvg-chno="368" channel-id="368",LA7 CINEMA
 rtp://239.186.64.164:10000
-#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset IT" tvg-logo="https://static.epg.best/it/20mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET
+#EXTINF:-1 tvg-id="20.it@SD" tvg-name="20 Mediaset" tvg-logo="https://static.epg.best/it/20mediaset.it.png" tvg-chno="370" channel-id="370",20 MEDIASET
 rtp://239.186.74.67:10000
-#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5 IT" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
+#EXTINF:-1 tvg-id="Canale5.it@SD" tvg-name="Canale 5" tvg-logo="https://static.epg.best/it/Canale5.it.png" tvg-chno="371" channel-id="371",MEDIASET Canale5
 rtp://239.186.64.46:10000
-#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra IT" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
+#EXTINF:-1 tvg-id="MediasetExtra.it@SD" tvg-name="Mediaset Extra" tvg-logo="https://static.epg.best/it/MediasetExtra.it.png" tvg-chno="373" channel-id="373",MEDIASET EXTRA
 rtp://239.186.66.37:10000
-#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus Tv IT" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
+#EXTINF:-1 tvg-id="Focus.it@SD" tvg-name="Focus" tvg-logo="https://static.epg.best/it/FocusTv.it.png" tvg-chno="374" channel-id="374",MEDIASET Focus
 rtp://239.186.66.69:10000
-#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1 IT" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
+#EXTINF:-1 tvg-id="Italia1.it@SD" tvg-name="Italia 1" tvg-logo="https://static.epg.best/it/Italia1.it.png" tvg-chno="375" channel-id="375",MEDIASET ITALIA1
 rtp://239.186.64.48:10000
-#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2 IT" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
+#EXTINF:-1 tvg-id="Italia2.it@SD" tvg-name="Italia 2" tvg-logo="https://static.epg.best/it/Italia2.it.png" tvg-chno="377" channel-id="377",MEDIASET ITALIA2
 rtp://239.186.66.44:10000
-#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="Iris IT" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
+#EXTINF:-1 tvg-id="Iris.it@SD" tvg-name="IRIS" tvg-logo="https://static.epg.best/it/Iris.it.png" tvg-chno="378" channel-id="378",MEDIASET IRIS
 rtp://239.186.64.75:10000
-#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5 IT" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
+#EXTINF:-1 tvg-id="La5.it@SD" tvg-name="La5" tvg-logo="https://static.epg.best/it/La5.it.png" tvg-chno="379" channel-id="379",MEDIASET LA5
 rtp://239.186.64.73:10000
 #EXTINF:-1 tvg-id="ReteQuattro.it" tvg-name="ReteQuattro IT" tvg-logo="https://static.epg.best/it/ReteQuattro.it.png" tvg-chno="380" channel-id="380",MEDIASET Rete4
 rtp://239.186.64.47:10000
-#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="Tgcom24 IT" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
+#EXTINF:-1 tvg-id="TGCom24.it@SD" tvg-name="TGCom24" tvg-logo="https://static.epg.best/it/Tgcom24.it.png" tvg-chno="381" channel-id="381",MEDIASET TGCOM24
 rtp://239.186.64.214:10000
-#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime IT" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
+#EXTINF:-1 tvg-id="TopCrime.it@SD" tvg-name="Top Crime" tvg-logo="https://static.epg.best/it/TopCrime.it.png" tvg-chno="382" channel-id="382",MEDIASET TOP crime
 rtp://239.186.66.180:10000
-#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34 IT" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34
+#EXTINF:-1 tvg-id="Cine34.it@SD" tvg-name="Cine34" tvg-logo="https://static.epg.best/it/Cine34.it.png" tvg-chno="" channel-id="",MEDIASET Cine34
 rtp://239.186.74.78:10000
-#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="radionorba IT" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="" channel-id="",radionorba TV
+#EXTINF:-1 tvg-id="RadioNorbaTV.it@SD" tvg-name="Radionorba TV" tvg-logo="https://static.epg.best/it/Radionorba.it.png" tvg-chno="" channel-id="",radionorba TV
 rtp://239.186.66.247:10000
-#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai Uno IT" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
+#EXTINF:-1 tvg-id="Rai1.it@SD" tvg-name="Rai 1" tvg-logo="https://static.epg.best/it/RaiUno.it.png" tvg-chno="384" channel-id="384",Rai1
 rtp://239.186.64.43:10000
-#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai Due IT" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
+#EXTINF:-1 tvg-id="Rai2.it@SD" tvg-name="Rai 2" tvg-logo="https://static.epg.best/it/RaiDue.it.png" tvg-chno="386" channel-id="386",Rai2
 rtp://239.186.64.44:10000
-#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai Tre IT" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
+#EXTINF:-1 tvg-id="Rai3.it@HD" tvg-name="Rai 3" tvg-logo="https://static.epg.best/it/RaiTre.it.png" tvg-chno="388" channel-id="388",Rai3
 rtp://239.186.64.45:10000
-#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4 IT" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
+#EXTINF:-1 tvg-id="Rai4.it@SD" tvg-name="Rai 4" tvg-logo="https://static.epg.best/it/Rai4.it.png" tvg-chno="390" channel-id="390",Rai4
 rtp://239.186.64.50:10000
-#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5 IT" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
+#EXTINF:-1 tvg-id="Rai5.it@SD" tvg-name="Rai 5" tvg-logo="https://static.epg.best/it/Rai5.it.png" tvg-chno="391" channel-id="391",Rai5
 rtp://239.186.66.179:10000
-#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp IT" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
+#EXTINF:-1 tvg-id="RaiGulp.it@SD" tvg-name="Rai Gulp" tvg-logo="https://static.epg.best/it/RaiGulp.it.png" tvg-chno="392" channel-id="392",Rai Gulp
 rtp://239.186.66.35:10000
-#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie IT" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
+#EXTINF:-1 tvg-id="RaiMovie.it@SD" tvg-name="Rai Movie" tvg-logo="https://static.epg.best/it/RaiMovie.it.png" tvg-chno="393" channel-id="393",Rai Movie
 rtp://239.186.66.185:10000
-#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24 IT" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
+#EXTINF:-1 tvg-id="RaiNews24.it@SD" tvg-name="Rai News 24" tvg-logo="https://static.epg.best/it/RaiNews.it.png" tvg-chno="394" channel-id="394",Rai News24
 rtp://239.186.64.156:10000
-#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium IT" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
+#EXTINF:-1 tvg-id="RaiPremium.it@SD" tvg-name="Rai Premium" tvg-logo="https://static.epg.best/it/RaiPremium.it.png" tvg-chno="395" channel-id="395",Rai Premium
 rtp://239.186.66.183:10000
-#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola IT" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
+#EXTINF:-1 tvg-id="RaiScuola.it@SD" tvg-name="Rai Scuola" tvg-logo="https://static.epg.best/it/RaiScuola.it.png" tvg-chno="396" channel-id="396",Rai Scuola
 rtp://239.186.66.34:10000
-#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="RaiSport+ IT" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport
+#EXTINF:-1 tvg-id="RaiSport.it@HD" tvg-name="Rai Sport +" tvg-logo="https://static.epg.best/it/RaiSportPlus.it.png" tvg-chno="397" channel-id="397",Rai Sport
 rtp://239.186.64.157:10000
-#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia IT" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
+#EXTINF:-1 tvg-id="RaiStoria.it@SD" tvg-name="Rai Storia" tvg-logo="https://static.epg.best/it/RaiStoria.it.png" tvg-chno="400" channel-id="400",Rai Storia
 rtp://239.186.64.162:10000
-#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo IT" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
+#EXTINF:-1 tvg-id="RaiYoyo.it@SD" tvg-name="Rai Yoyo" tvg-logo="https://static.epg.best/it/RaiYoyo.it.png" tvg-chno="401" channel-id="401",Rai Yoyo
 rtp://239.186.66.182:10000
-#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="Sky TG24 IT" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
+#EXTINF:-1 tvg-id="SkyTG24.it@SD" tvg-name="sky TG 24" tvg-logo="https://static.epg.best/it/SkyTG24.it.png" tvg-chno="406" channel-id="406",sky tg24
 rtp://239.186.66.177:10000
-#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="Sportitalia IT" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sportitalia plus
+#EXTINF:-1 tvg-id="Sportitalia.it@SD" tvg-name="SPORTITALIA" tvg-logo="https://static.epg.best/it/Sportitalia.it.png" tvg-chno="408" channel-id="408",Sportitalia plus
 rtp://239.186.74.24:10000
-#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super IT" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
+#EXTINF:-1 tvg-id="Super.it@SD" tvg-name="Super!" tvg-logo="https://static.epg.best/it/Super.it.png" tvg-chno="291" channel-id="291",SUPER!
 rtp://239.186.66.181:10000
-#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="teleticino CH" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="410" channel-id="410",teleticino
+#EXTINF:-1 tvg-id="TeleTicino.ch@SD" tvg-name="Tele Ticino" tvg-logo="https://static.epg.best/ch/teleticino.ch.png" tvg-chno="410" channel-id="410",teleticino
 rtp://239.186.64.99:10000
-#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
+#EXTINF:-1 tvg-id="Telelombardia.it@SD" tvg-name="Telelombardia" tvg-logo="" tvg-chno="412" channel-id="412",TELELOMBARDIA
 rtp://239.186.64.154:10000
-#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
+#EXTINF:-1 tvg-id="Telenova.it@SD" tvg-name="Telenova" tvg-logo="" tvg-chno="413" channel-id="413",TELENOVA
 rtp://239.186.64.152:10000
-#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 IT" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8" tvg-logo="https://static.epg.best/it/TV8.it.png" tvg-chno="416" channel-id="416",tv8 Italia
 rtp://239.186.64.161:10000
-#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO.TV
+#EXTINF:-1 tvg-id="UniNettunoUniversityTV.it@SD" tvg-name="UniNettuno University TV" tvg-logo="" tvg-chno="417" channel-id="417",UNINETTUNO.TV
 rtp://239.186.66.184:10000
-#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000 IT" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000
+#EXTINF:-1 tvg-id="TV2000.it@SD" tvg-name="TV2000" tvg-logo="https://static.epg.best/it/TV2000.it.png" tvg-chno="415" channel-id="415",TV2000
 rtp://239.186.66.108:10000
-#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione IT" tvg-logo="https://static.epg.best/it/espansione.it.png",Espansione TV
+#EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione TV" tvg-logo="https://static.epg.best/it/espansione.it.png",Espansione TV
 rtp://239.186.74.22:10000
-#EXTINF:-1 tvg-id="95" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
+#EXTINF:-1 tvg-id="" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
 rtp://239.186.74.71:10000
-#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="discovery IT" tvg-logo="http://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I
+#EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="Discovery F" tvg-logo="http://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I
 rtp://239.186.64.191:10000
-#EXTINF:-1 tvg-id="TopCalcio24.it@SD" ,TOP CALCIO 24
+#EXTINF:-1 tvg-id="TopCalcio24.it@SD"  tvg-name="Top Calcio 24",TOP CALCIO 24
 rtp://239.186.74.79:10000
-#EXTINF:-1 tvg-id="SenatoTV.it@SD" ,senato italiano tv
+#EXTINF:-1 tvg-id="SenatoTV.it@SD"  tvg-name="Senato TV",senato italiano tv
 rtp://239.186.74.85:10000
-#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD" ,camera dei deputati
+#EXTINF:-1 tvg-id="CameradeiDeputati.it@SD"  tvg-name="Camera dei Deputati",camera dei deputati
 rtp://239.186.74.59:10000
-#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="twenty seven IT" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 italian
+#EXTINF:-1 tvg-id="Twentyseven.it@SD" tvg-name="Twentyseven" tvg-logo="https://static.epg.best/it/twentyseven.it.png" tvg-chno="" channel-id="",MEDIASET twenty seven 27 italian
 rtp://239.186.74.114:10000
 #EXTREM:portuguese
-#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="RecordTV BR" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record TV
+#EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record TV
 rtp://239.186.64.83:10000
-#EXTINF:-1 tvg-id="1685" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
 rtp://239.186.64.77:10000
 #EXTREM:spanish
-#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="aragon TV ES" tvg-logo="https://static.epg.best/es/aragontv.es.png" tvg-chno="" channel-id="",Aragon int
+#EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragón TV Int" tvg-logo="https://static.epg.best/es/aragontv.es.png" tvg-chno="" channel-id="",Aragon int
 rtp://239.186.66.62:10000
-#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="24 Horas ES" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
+#EXTINF:-1 tvg-id="OraTV.al@SD" tvg-name="TV Ora" tvg-logo="https://static.epg.best/es/24Horas.es.png" tvg-chno="422" channel-id="422",Canal 24 Horas
 rtp://239.186.64.196:10000
-#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia
+#EXTINF:-1 tvg-id="CanalSurAndalucia.es@SD" tvg-name="Canal Sur Andalucía" tvg-logo="" tvg-chno="467" channel-id="467",Andalucia
 rtp://239.186.64.197:10000
-#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="TV Galicia ES" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
+#EXTINF:-1 tvg-id="GaliciaTVEuropa.es@SD" tvg-name="Televisión de Galicia" tvg-logo="https://static.epg.best/es/TVGalicia.es.png" tvg-chno="468" channel-id="468",Galicia
 rtp://239.186.64.187:10000
-#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="tve ES" tvg-logo="https://static.epg.best/es/tve.es.png" tvg-chno="469" channel-id="469",tve international
+#EXTINF:-1 tvg-id="TVEInternacionalEuropeAsia.es@SD" tvg-name="TVE Internacional" tvg-logo="https://static.epg.best/es/tve.es.png" tvg-chno="469" channel-id="469",tve international
 rtp://239.186.64.54:10000
 #EXTREM:turkish
-#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360 TR" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk
+#EXTINF:-1 tvg-id="360.tr@SD"360.tr tvg-name="360" tvg-logo="https://static.epg.best/tr/360.tr.png" tvg-chno="420" channel-id="420",360 Turk
 rtp://239.186.64.204:10000
-#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="" tvg-logo="" tvg-chno="421" channel-id="421",atv turk
+#EXTINF:-1 tvg-id="ATV.tr@SD" tvg-name="ATV (TR)" tvg-logo="" tvg-chno="421" channel-id="421",atv turk
 rtp://239.186.64.201:10000
-#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax TR" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
+#EXTINF:-1 tvg-id="ShowMax.tr@SD" tvg-name="Showmax" tvg-logo="https://static.epg.best/tr/Showmax.tr.png" tvg-chno="428" channel-id="428",SHOW MAX
 rtp://239.186.64.209:10000
-#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show TV TR" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
+#EXTINF:-1 tvg-id="ShowTV.tr@SD" tvg-name="Show" tvg-logo="https://static.epg.best/tr/ShowTV.tr.png" tvg-chno="429" channel-id="429",SHOW TURK
 rtp://239.186.64.200:10000
-#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Turk TR" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
+#EXTINF:-1 tvg-id="TRTTurk.tr@SD" tvg-name="TRT Türk" tvg-logo="https://static.epg.best/tr/TRTTurk.tr.png" tvg-chno="430" channel-id="430",TRT TURK
 rtp://239.186.64.188:10000
-#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8 TR" tvg-logo="https://static.epg.best/tr/TV8.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
+#EXTINF:-1 tvg-id="TV8.it@SD" tvg-name="TV8" tvg-logo="https://static.epg.best/tr/TV8.tr.png" tvg-chno="431" channel-id="431",TV8int Turkey
 rtp://239.186.64.205:10000
-#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Eurostar TR" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
+#EXTINF:-1 tvg-id="EuroStar.tr@SD" tvg-name="Euro Star" tvg-logo="https://static.epg.best/tr/Eurostar.tr.png" tvg-chno="425" channel-id="425",EURO STAR
 rtp://239.186.66.121:10000
-#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D TR" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",EURO D
+#EXTINF:-1 tvg-id="EuroD.tr@SD" tvg-name="Euro D" tvg-logo="https://static.epg.best/tr/EuroD.tr.png" tvg-chno="424" channel-id="424",EURO D
 rtp://239.186.64.199:10000
-#EXTINF:-1 tvg-id="602" tvg-name="" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
+#EXTINF:-1 tvg-id="" tvg-name="TGRT EU" tvg-logo="" tvg-chno="462" channel-id="462",TGRT EU
 rtp://239.186.64.203:10000
-#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdî TR" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
+#EXTINF:-1 tvg-id="TRTKurdi.tr@SD" tvg-name="TRT Kurdi" tvg-logo="https://static.epg.best/tr/TRTKurdi.tr.png" tvg-chno="463" channel-id="463",TRT KURDI
 rtp://239.186.66.204:10000
-#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNN Turk TR" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
+#EXTINF:-1 tvg-id="CNNTurk.tr@SD" tvg-name="CNN Türk" tvg-logo="https://static.epg.best/tr/CNNTurk.tr.png" tvg-chno="" channel-id="",CNN Turk
 rtp://239.186.74.75:10000
 #EXTREM:others foreign language not listed above
-#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde MA" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
+#EXTINF:-1 tvg-id="2MMonde.ma@SD" tvg-name="2M Monde" tvg-logo="https://static.epg.best/ma/2MMonde.ma.png" tvg-chno="419" channel-id="419",2M MONDE
 rtp://239.186.64.194:10000
-#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya SA" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
+#EXTINF:-1 tvg-id="Alarabiya.ae@SD" tvg-name="Al Arabiya" tvg-logo="https://static.epg.best/sa/Alarabiya.sa.png" tvg-chno="432" channel-id="432",Al Arabiya
 rtp://239.186.64.192:10000
-#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN NL" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
+#EXTINF:-1 tvg-id="BVN.nl@SD" tvg-name="BVN TV" tvg-logo="https://static.epg.best/nl/BVN.nl.png" tvg-chno="434" channel-id="434",bvn.
 rtp://239.186.64.189:10000
-#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV 4 Europe CN" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
+#EXTINF:-1 tvg-id="CCTV4Europe.cn@SD" tvg-name="CCTV4" tvg-logo="https://static.epg.best/cn/CCTV4Europe.cn.png" tvg-chno="435" channel-id="435",CCTV4
 rtp://239.186.64.195:10000
-#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
+#EXTINF:-1 tvg-id="DMSat.rs@SD" tvg-name="DM Sat TV" tvg-logo="" tvg-chno="439" channel-id="439",DM SAT
 rtp://239.186.64.79:10000
-#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV AE" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI TV
+#EXTINF:-1 tvg-id="DubaiTV.ae@SD" tvg-name="Dubai TV" tvg-logo="https://static.epg.best/ae/DubaiTV.ae.png" tvg-chno="440" channel-id="440",DUBAI TV
 rtp://239.186.66.119:10000
-#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV HU" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
+#EXTINF:-1 tvg-id="Duna.hu@SD" tvg-name="Duna TV" tvg-logo="https://static.epg.best/hu/DunaTV.hu.png" tvg-chno="441" channel-id="441",DUNA
 rtp://239.186.74.52:10000
-#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World HU" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
+#EXTINF:-1 tvg-id="DunaWorld.hu@SD" tvg-name="Duna World" tvg-logo="https://static.epg.best/hu/DunaWorld.hu.png" tvg-chno="442" channel-id="442",DUNA WORLD
 rtp://239.186.66.85:10000
-#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya EG" tvg-logo="https://static.epg.best/eg/Almasriya.eg.png" tvg-chno="443" channel-id="443",Al Masriya
+#EXTINF:-1 tvg-id="AlMasriyah.eg@SD" tvg-name="Al Masriya" tvg-logo="https://static.epg.best/eg/Almasriya.eg.png" tvg-chno="443" channel-id="443",Al Masriya
 rtp://239.186.64.193:10000
-#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World GR" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
+#EXTINF:-1 tvg-id="ERTWorld.gr@SD" tvg-name="ERT World" tvg-logo="https://static.epg.best/gr/ERTWorld.gr.png" tvg-chno="444" channel-id="444",ERT world
 rtp://239.186.66.227:10000
-#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="HTV 1 HR" tvg-logo="https://static.epg.best/hr/Htv1.hr.png" tvg-chno="446" channel-id="446",HRT1
+#EXTINF:-1 tvg-id="ITV1.uk@London" tvg-name="ITV1" tvg-logo="https://static.epg.best/hr/Htv1.hr.png" tvg-chno="446" channel-id="446",HRT1
 rtp://239.186.66.125:10000
 #EXTINF:-1 tvg-id="KCN3SvetPlus.rs" tvg-name="KCN 3 Svet Plus RS" tvg-logo="https://static.epg.best/rs/KCN3SvetPlus.rs.png" tvg-chno="447" channel-id="447",KCN3 Svet Plus3
 rtp://239.186.66.141:10000
-#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN tv
+#EXTINF:-1 tvg-id="KurdistanTV.iq@SD" tvg-name="Kurdistan TV" tvg-logo="" tvg-chno="448" channel-id="448",KURDISTAN tv
 rtp://239.186.66.203:10000
-#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
+#EXTINF:-1 tvg-id="phoenix.de@HD" tvg-name="Phoenix TV" tvg-logo="" tvg-chno="451" channel-id="451",PHOENIX NEWS taiwan
 rtp://239.186.66.132:10000
 #EXTINF:-1 tvg-id="PlanetaRTR.ru" tvg-name="Planeta RTR " tvg-logo="https://static.epg.best/tr/PlanetaRTR.ru.png" tvg-chno="452" channel-id="452",PLANETA RTR
 rtp://239.186.66.138:10000
-#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV RO" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
+#EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="https://static.epg.best/ro/ProTV.ro.png" tvg-chno="455" channel-id="455",PRO TV INTERNATIONAL
 rtp://239.186.66.135:10000
 #EXTINF:-1 tvg-id="RiK.sk" tvg-name="RiK SK" tvg-logo="https://static.epg.best/sk/RiK.sk.png" tvg-chno="456" channel-id="456",RiK Sat
 rtp://239.186.66.137:10000
-#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK AL" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
+#EXTINF:-1 tvg-id="RTK1.xk@SD" tvg-name="RTK1" tvg-logo="https://static.epg.best/al/RTK.al.png" tvg-chno="457" channel-id="457",RTK1
 rtp://239.186.64.81:10000
-#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia PL" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
+#EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
-#EXTINF:-1 tvg-id="371" tvg-name="TVRi RO" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="" tvg-name="TVRi RO" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
-#EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-name="AlJazeeraArabic QA" tvg-logo="https://static.epg.best/qa/AlJazeera.qa.png" tvg-chno="115" channel-id="115",Al Jazeera Arabic
+#EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-name="Al Jazeera" tvg-logo="https://static.epg.best/qa/AlJazeera.qa.png" tvg-chno="115" channel-id="115",Al Jazeera Arabic
 rtp://239.186.64.173:10000
-#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD" ,TV Duga+ (bos)
+#EXTINF:-1 tvg-id="TVDugaPlus.rs@SD"  tvg-name="TV Duga+",TV Duga+ (bos)
 rtp://239.186.74.77:10000
-#EXTINF:-1 tvg-id="HRTInternational.hr@SD" ,HRT int. (hrv)
+#EXTINF:-1 tvg-id="HRTInternational.hr@SD"  tvg-name="HRT Int.",HRT int. (hrv)
 rtp://239.186.74.83:10000
-#EXTINF:-1 tvg-id="ElWatania1.tn@SD" ,Tunisie Nationale (ara)
+#EXTINF:-1 tvg-id="ElWatania1.tn@SD"  tvg-name="Tunisie Nationale",Tunisie Nationale (ara)
 rtp://239.186.74.89:10000
-#EXTINF:-1 tvg-id="1919" ,YKPAÏHA 24  / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="" ,YKPAÏHA 24  / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 ,Espreso TV (ukr)
 rtp://239.186.74.158:10000
-#EXTINF:-1 tvg-id="2081" ,1+1 int. (ukr)
+#EXTINF:-1 tvg-id=""  tvg-name="1+1 Int.",1+1 int. (ukr)
 rtp://239.186.74.9:10000
-#EXTINF:-1 tvg-id="371" ,RTVI (rus)
+#EXTINF:-1 tvg-id=""  tvg-name="RTVi",RTVI (rus)
 rtp://239.186.74.2:10000

--- a/swisscom-sd.m3u
+++ b/swisscom-sd.m3u
@@ -90,7 +90,7 @@ rtp://239.186.64.51:10000
 rtp://239.186.64.165:10000
 #EXTINF:-1 tvg-id="CBBC.uk@SD" tvg-name="BBC Three / CBBC" tvg-logo="https://static.epg.best/gb/CBBC.uk.png" tvg-chno="122" channel-id="122",BBC CBBC / BBC THREE
 rtp://239.186.64.166:10000
-#EXTINF:-1 tvg-id="" tvg-name="BBC4 UK" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
+#EXTINF:-1 tvg-id="BBCFour.uk@UK" tvg-name="BBC Four" tvg-logo="https://static.epg.best/gb/BBC4.uk.png" tvg-chno="124" channel-id="124",BBC FOUR /Cbeebies
 rtp://239.186.64.52:10000
 #EXTINF:-1 tvg-id="CBeebies.uk@SD" tvg-name="CBeebies" tvg-logo="https://static.epg.best/gb/CBeebies.uk.png" tvg-chno="126" channel-id="126",BBC CBeebies / BBC Four
 rtp://239.186.64.113:10000
@@ -116,7 +116,7 @@ rtp://239.186.64.167:10000
 rtp://239.186.64.175:10000
 #EXTINF:-1 tvg-id="DeutscheWelleEn.de" tvg-name="DeutscheWelleEn DE" tvg-logo="https://static.epg.best/de/DeutscheWelleEn.de.png" tvg-chno="207" channel-id="207",DEUTSCHE WELLE En
 rtp://239.186.64.135:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Drama UK" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
+#EXTINF:-1 tvg-id="UandDrama.uk" tvg-name="Drama" tvg-logo="https://static.epg.best/uk/UandDrama.uk.png" tvg-chno="146" channel-id="146",U&DRAMA
 rtp://239.186.66.140:10000
 #EXTINF:-1 tvg-id="E4.uk@SD" tvg-name="E4" tvg-logo="https://static.epg.best/gb/E4.uk.png" tvg-chno="147" channel-id="147",E4
 rtp://239.186.64.53:10000
@@ -150,7 +150,7 @@ rtp://239.186.66.242:10000
 rtp://239.186.74.25:10000
 #EXTINF:-1 tvg-id="PBSAmerica.uk@SD" tvg-name="PBS America" tvg-logo="https://static.epg.best/gb/PBSAmerica.uk.png" tvg-chno="" channel-id="",PBS America UK
 rtp://239.186.66.243:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Dave UK" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
+#EXTINF:-1 tvg-id="UandDave.uk" tvg-name="Dave" tvg-logo="https://static.epg.best/gb/Uanddave.uk.png" tvg-chno="" channel-id="",U&Dave
 rtp://239.186.66.253:10000
 #EXTINF:-1 tvg-id="5STAR.uk@SD" tvg-name="5Star" tvg-logo="https://static.epg.best/gb/5star.uk.png" tvg-chno="" channel-id="",5STAR
 rtp://239.186.74.72:10000
@@ -160,11 +160,11 @@ rtp://239.186.74.88:10000
 rtp://239.186.74.74:10000
 #EXTINF:-1 tvg-id="5Action.uk@SD" tvg-name="5Action" tvg-logo="https://static.epg.best/gb/5ACTION.uk.png" tvg-chno="" channel-id="",5ACTION
 rtp://239.186.74.84:10000
-#EXTINF:-1 tvg-id="" tvg-name="U&Yesterday UK" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
+#EXTINF:-1 tvg-id="UandYesterday.uk" tvg-name="Yesterday" tvg-logo="https://static.epg.best/gb/UandYesterday.uk.png" tvg-chno="" channel-id="",U&Yesterday
 rtp://239.186.74.87:10000
 #EXTINF:-1 tvg-id="4seven.uk@SD" tvg-name="4Seven" tvg-logo="https://static.epg.best/gb/4Seven.uk.png" tvg-chno="" channel-id="",Channel4 7
 rtp://239.186.74.93:10000
-#EXTINF:-1 tvg-id="" tvg-name="skymix UK" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
+#EXTINF:-1 tvg-id="SkyMix.uk@SD" tvg-name="Pick" tvg-logo="https://static.epg.best/uk/skymix.uk.png" tvg-chno="" channel-id="",sky mix
 rtp://239.186.74.94:10000
 #EXTINF:-1 tvg-id="Challenge.uk@SD" tvg-name="Challenge" tvg-logo="https://static.epg.best/gb/Challenge.uk.png" tvg-chno="" channel-id="",Challenge
 rtp://239.186.74.95:10000
@@ -229,13 +229,13 @@ rtp://239.186.64.31:10000
 rtp://239.186.64.133:10000
 #EXTINF:-1 tvg-id="LolyTV.ch@SD" tvg-name="Loly TV" tvg-logo="https://static.epg.best/ch/Loly.ch.png" tvg-chno="228" channel-id="228",LOLY
 rtp://239.186.66.231:10000
-#EXTINF:-1 tvg-id="" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
+#EXTINF:-1 tvg-id="MDR.de" tvg-name="MDR" tvg-logo="https://static.epg.best/de/MDR.de.png" tvg-chno="229" channel-id="229",mdr
 rtp://239.186.64.63:10000
 #EXTINF:-1 tvg-id="MelodieTV.at@SD" tvg-name="MelodieTV" tvg-logo="" tvg-chno="231" channel-id="231",Melodie.tv
 rtp://239.186.74.15:10000
 #EXTINF:-1 tvg-id="N24Doku.de@SD" tvg-name="N24 Doku" tvg-logo="https://static.epg.best/de/N24Doku.de.png" tvg-chno="235" channel-id="235",N24 Doku
 rtp://239.186.66.232:10000
-#EXTINF:-1 tvg-id="" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
+#EXTINF:-1 tvg-id="ndr.de" tvg-name="NDR" tvg-logo="https://static.epg.best/de/ndr.de.png" tvg-chno="236" channel-id="236",NDR
 rtp://239.186.64.25:10000
 #EXTINF:-1 tvg-id="7PlusNickSchweiz.ch@SD" tvg-name="7+ / Nickelodeon" tvg-logo="https://static.epg.best/ch/7Plus.ch.png" tvg-chno="238" channel-id="238",7+
 rtp://239.186.64.186:10000
@@ -253,11 +253,11 @@ rtp://239.186.64.86:10000
 rtp://239.186.64.65:10000
 #EXTINF:-1 tvg-id="PROTVInternational.ro@SD" tvg-name="Pro TV International" tvg-logo="https://static.epg.best/de/ProSieben.de.png" tvg-chno="251" channel-id="251",ProSieben
 rtp://239.186.64.19:10000
-#EXTINF:-1 tvg-id="" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
+#EXTINF:-1 tvg-id="RBB.de" tvg-name="RBB" tvg-logo="https://static.epg.best/de/RBB.de.png" tvg-chno="256" channel-id="256",rbb
 rtp://239.186.64.126:10000
 #EXTINF:-1 tvg-id="RTL.de@SD" tvg-name="RTL" tvg-logo="https://static.epg.best/de/RTL.de.png" tvg-chno="259" channel-id="259",RTL CH
 rtp://239.186.64.15:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTL 2 DE" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
+#EXTINF:-1 tvg-id="RTLZwei.de@SD" tvg-name="RTL ZWEI" tvg-logo="https://static.epg.best/de/RTL2.de.png" tvg-chno="261" channel-id="261",RTL ZWEI CH
 rtp://239.186.64.16:10000
 #EXTINF:-1 tvg-id="RTLup.de@SD" tvg-name="RTLup" tvg-logo="https://static.epg.best/de/RTLUp.de.png" tvg-chno="262" channel-id="262",RTLup
 rtp://239.186.66.201:10000
@@ -307,7 +307,7 @@ rtp://239.186.64.100:10000
 rtp://239.186.64.94:10000
 #EXTINF:-1 tvg-id="VOX.de@SD" tvg-name="VOX" tvg-logo="https://static.epg.best/de/Vox.de.png" tvg-chno="333" channel-id="333",VOX
 rtp://239.186.64.21:10000
-#EXTINF:-1 tvg-id="" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
+#EXTINF:-1 tvg-id="WDR.de" tvg-name="WDR" tvg-logo="https://static.epg.best/de/WDR.de.png" tvg-chno="334" channel-id="334",WDR
 rtp://239.186.64.24:10000
 #EXTINF:-1 tvg-id="WELT.de@SD" tvg-name="WELT" tvg-logo="https://static.epg.best/de/Welt.de.png" tvg-chno="336" channel-id="336",WeLT
 rtp://239.186.64.30:10000
@@ -450,7 +450,7 @@ rtp://239.186.66.184:10000
 rtp://239.186.66.108:10000
 #EXTINF:-1 tvg-id="EspansioneTV.it@SD" tvg-name="Espansione TV" tvg-logo="https://static.epg.best/it/espansione.it.png",Espansione TV
 rtp://239.186.74.22:10000
-#EXTINF:-1 tvg-id="" tvg-name="HGTV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
+#EXTINF:-1 tvg-id="HGTV.it@SD" tvg-name="Home & Garden TV IT" tvg-logo="https://static.epg.best/it/HGTV.it.png" tvg-chno="" channel-id="",Warner Bros Discovery HGTV I
 rtp://239.186.74.71:10000
 #EXTINF:-1 tvg-id="DiscoveryChannel.fr@SD" tvg-name="Discovery F" tvg-logo="http://static.epg.best/it/discovery.it.png" tvg-chno="" channel-id="",Discovery I
 rtp://239.186.64.191:10000
@@ -465,7 +465,7 @@ rtp://239.186.74.114:10000
 #EXTREM:portuguese
 #EXTINF:-1 tvg-id="RecordTVEuropa.pt@SD" tvg-name="Record TV" tvg-logo="https://static.epg.best/br/RecordTV.br.png" tvg-chno="470" channel-id="470",Record TV
 rtp://239.186.64.83:10000
-#EXTINF:-1 tvg-id="" tvg-name="RTP Internacional PT" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Int.
+#EXTINF:-1 tvg-id="RTPMundo.pt@SD" tvg-name="RTP Mundo" tvg-logo="https://static.epg.best/pt/RTPInternacional.pt.png" tvg-chno="472" channel-id="472",RTP Mundo
 rtp://239.186.64.77:10000
 #EXTREM:spanish
 #EXTINF:-1 tvg-id="AragonTVInternacional.es@SD" tvg-name="Aragón TV Int" tvg-logo="https://static.epg.best/es/aragontv.es.png" tvg-chno="" channel-id="",Aragon int
@@ -540,7 +540,7 @@ rtp://239.186.66.137:10000
 rtp://239.186.64.81:10000
 #EXTINF:-1 tvg-id="TVPPolonia.pl@SD" tvg-name="TVP Polonia" tvg-logo="https://static.epg.best/pl/TVPPolonia.pl.png" tvg-chno="464" channel-id="464",TVP POLONIA
 rtp://239.186.66.147:10000
-#EXTINF:-1 tvg-id="" tvg-name="TVRi RO" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
+#EXTINF:-1 tvg-id="TVRInternational.ro@SD" tvg-name="TV Romania International" tvg-logo="https://static.epg.best/ro/TVRi.ro.png" tvg-chno="465" channel-id="465",TVRi TV Romania International
 rtp://239.186.66.148:10000
 #EXTINF:-1 tvg-id="AlJazeera.qa@Arabic" tvg-name="Al Jazeera" tvg-logo="https://static.epg.best/qa/AlJazeera.qa.png" tvg-chno="115" channel-id="115",Al Jazeera Arabic
 rtp://239.186.64.173:10000
@@ -550,7 +550,7 @@ rtp://239.186.74.77:10000
 rtp://239.186.74.83:10000
 #EXTINF:-1 tvg-id="ElWatania1.tn@SD"  tvg-name="Tunisie Nationale",Tunisie Nationale (ara)
 rtp://239.186.74.89:10000
-#EXTINF:-1 tvg-id="" ,YKPAÏHA 24  / FREEDOM UA (ukr)
+#EXTINF:-1 tvg-id="" tvg-name="Freedom",YKPAÏHA 24  / FREEDOM UA (ukr)
 rtp://239.186.74.98:10000
 #EXTINF:-1 ,Espreso TV (ukr)
 rtp://239.186.74.158:10000

--- a/swisscom-uhd.m3u
+++ b/swisscom-uhd.m3u
@@ -1,13 +1,13 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="UHD1.lu@SD" ,UHD1 Astra UHD
+#EXTINF:-1 tvg-id="UHD1.lu@SD"  tvg-name="UHD1 by ASTRA",UHD1 Astra UHD
 rtp://239.186.76.1:10000
-#EXTINF:-1 tvg-id="1908" ,3+ UHD
+#EXTINF:-1 tvg-id="3Plus.ch@SD"  tvg-name="3+",3+ UHD
 rtp://239.186.76.8:10000
-#EXTINF:-1 tvg-id="1909" ,4+ UHD
+#EXTINF:-1 tvg-id="4Plus.ch@SD"  tvg-name="4+",4+ UHD
 rtp://239.186.76.19:10000
-#EXTINF:-1 tvg-id="1910" ,TV24 UHD
+#EXTINF:-1 tvg-id="TV24.ch@SD"  tvg-name="TV24",TV24 UHD
 rtp://239.186.76.33:10000
-#EXTINF:-1 tvg-id="UHD1.lu@SD" ,UHD1 by ASTRA
+#EXTINF:-1 tvg-id="UHD1.lu@SD"  tvg-name="UHD1 by ASTRA",UHD1 by ASTRA
 rtp://239.186.79.26:10000
-#EXTINF:-1 tvg-id="France2.fr@SD" ,France2 UHD (source network netplus)
+#EXTINF:-1 tvg-id="France2.fr@SD"  tvg-name="France 2",France2 UHD (source network netplus)
 udp://@239.101.10.2:1234

--- a/swisscom-uhd.m3u
+++ b/swisscom-uhd.m3u
@@ -1,13 +1,13 @@
 #EXTM3U
-#EXTINF:-1 ,UHD1 Astra UHD
+#EXTINF:-1 tvg-id="UHD1.lu@SD" ,UHD1 Astra UHD
 rtp://239.186.76.1:10000
-#EXTINF:-1 ,3+ UHD
+#EXTINF:-1 tvg-id="1908" ,3+ UHD
 rtp://239.186.76.8:10000
-#EXTINF:-1 ,4+ UHD
+#EXTINF:-1 tvg-id="1909" ,4+ UHD
 rtp://239.186.76.19:10000
-#EXTINF:-1 ,TV24 UHD
+#EXTINF:-1 tvg-id="1910" ,TV24 UHD
 rtp://239.186.76.33:10000
-#EXTINF:-1 ,UHD1 by ASTRA
+#EXTINF:-1 tvg-id="UHD1.lu@SD" ,UHD1 by ASTRA
 rtp://239.186.79.26:10000
-#EXTINF:-1 ,France2 UHD (source network netplus)
+#EXTINF:-1 tvg-id="France2.fr@SD" ,France2 UHD (source network netplus)
 udp://@239.101.10.2:1234


### PR DESCRIPTION
The telerama tvg-ids and tvg-names are not relevant any more after the dead of the the xmltv.ch
This PR is updating them to the widely used tvg-ids and tvg-names from https://github.com/iptv-org/epg